### PR TITLE
Slug release channels in marker generation

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -41,5 +41,7 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
 
 def build_release_marker(version: str, channel: str) -> str:
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
-    normalized_channel = channel.strip().lower() or "internal"
+    normalized_channel = channel.strip().lower().replace(" ", "-").replace("_", "-")
+    normalized_channel = "-".join(part for part in normalized_channel.split("-") if part)
+    normalized_channel = normalized_channel or "internal"
     return f"{version}-{normalized_channel}-{timestamp}"


### PR DESCRIPTION
## Summary
- normalize release channels before building the marker
- keep the marker safe for channels copied from support notes or release docs

## Context
Support hit a cutoff run where the channel value came through as `internal ops`, which left a space in the marker. Main needs the fix first so the maintenance train can pick it up cleanly.

## Acceptance criteria
- channel values with spaces or underscores produce a single hyphenated token
- the release-train backport carries the same change
- prod marker confirmation is recorded before the release tracker is closed
