### PR TITLE
Backport release marker channel fix to 2026-05-21 train

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -41,5 +41,7 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
 
 def build_release_marker(version: str, channel: str) -> str:
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
-    normalized_channel = channel.strip().lower() or "internal"
+    normalized_channel = channel.strip().lower().replace(" ", "-").replace("_", "-")
+    normalized_channel = "-".join(part for part in normalized_channel.split("-") if part)
+    normalized_channel = normalized_channel or "internal"
     return f"{version}-{normalized_channel}-{timestamp}"


### PR DESCRIPTION
## Summary
- carry the release marker channel fix onto the 2026-05-21 maintenance train
- keep the branch behavior aligned with the mainline fix

## Context
This is the release-branch follow-up for #93. Merge the mainline fix first, then keep this branch moving with release review until production confirmation lands.

## Acceptance criteria
- same marker slugging behavior as main
- train owner confirms the backport is on the 2026-05-21 cut
- Support confirms the production marker after rollout
