### PR TITLE
Document release marker rollout and rollback checks

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -16,6 +16,8 @@ Before marking a release-facing PR as ready, confirm:
 - Operational runbooks match the implementation.
 - Rollback and owner information are present.
 
+For release marker changes, confirm the channel token is URL-safe, keep the maintenance-train backport in sync, and wait for Support to confirm the marker in production before closing the tracker.
+
 ## Tracking hygiene
 
 Merged PRs should have a completed work item. Open PRs should either link to active tracking or make the missing owner explicit in the PR discussion.


### PR DESCRIPTION
## Summary
- add the marker rollout checks to the runbook
- call out the production confirmation step before release closeout

## Context
This is the follow-up note for the release-marker change set so the main fix and release-branch follow-up read as one release path instead of three separate bits of work.

## Acceptance criteria
- release review uses the same marker checks on main and the maintenance train
- rollback and production confirmation owners are clear in the PR thread
