### PR TITLE
Tune flaky rerun budget for mirror timeouts

### DIFF
--- a/config/operations.yml
+++ b/config/operations.yml
@@ -13,7 +13,7 @@ ci:
   required_jobs:
     - unit-tests
     - repository-baseline
-  flaky_test_budget: 2
+  flaky_test_budget: 3
 
 ownership:
   default_owner: platform-ops

--- a/config/operations.yml
+++ b/config/operations.yml
@@ -14,6 +14,7 @@ ci:
     - unit-tests
     - repository-baseline
   flaky_test_budget: 3
+  rerun_owner: qa
 
 ownership:
   default_owner: platform-ops


### PR DESCRIPTION
## Summary
- raise the allowed rerun budget for mirror-timeout smoke failures

## Context
The smoke job has been bouncing on the artifact mirror more often this week. The goal is to keep accepted reruns inside the normal review path instead of forcing every timeout into release escalation.

## Acceptance criteria
- the current head gets a fresh review
- the accepted rerun path stays owned and visible in the PR thread
- no change lands without release acknowledging the current budget
