### PR TITLE
Refresh retention backfill validation pointer

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,4 +4,5 @@
 - Check incident-routing configuration.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
+- Record the retention backfill dry-run head before merge.
 - Tag unresolved risks before release cutoff.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,5 +4,5 @@
 - Check incident-routing configuration.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
-- Record the retention backfill dry-run head before merge.
+- Record the retention backfill dry-run head and rollback note together before merge.
 - Tag unresolved risks before release cutoff.


### PR DESCRIPTION
## Summary
- add the retention backfill validation line item to the release checklist

## Context
The dry run attached to the release thread was captured on validation head `1f356a2af367e0583eaf578b1aec46811cb49664`. Keep the branch open until the same backfill check is re-run on the current head and the rollback note is refreshed.

## Acceptance criteria
- current-head dry-run output is attached
- rollback note and validation head are updated together
- release review acknowledges the current evidence before merge
