### PR TITLE
Document accepted reruns for mirror timeout smoke failures

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -16,6 +16,8 @@ Before marking a release-facing PR as ready, confirm:
 - Operational runbooks match the implementation.
 - Rollback and owner information are present.
 
+Known mirror timeout failures may be rerun once on the same head when QA records the accepted rerun in the PR thread.
+
 ## Tracking hygiene
 
 Merged PRs should have a completed work item. Open PRs should either link to active tracking or make the missing owner explicit in the PR discussion.


### PR DESCRIPTION
## Summary
- document the accepted rerun path for mirror timeout smoke failures

## Context
The mirror has been noisy enough that reviewers are asking for the same clarification in-thread. This keeps the decision path in the runbook without changing product behavior.

## Acceptance criteria
- accepted reruns stay on the same head
- QA records the accepted rerun in the PR thread
