### PR TITLE
Require retention delete gate before cleanup merge

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,4 +4,5 @@
 - Check incident-routing configuration.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
+- Require the retention-delete policy gate to pass on protected rows before cleanup merges.
 - Tag unresolved risks before release cutoff.


### PR DESCRIPTION
## Summary
- make the retention-delete gate explicit in the release checklist for cleanup merges

## Current check snapshot
![smoke](https://img.shields.io/badge/smoke-passing-brightgreen)

- smoke summary: passing
- required check: `retention-delete-policy` failing on protected rows
- release approval: still pending

## Context
Cleanup work keeps showing a green smoke summary while the protected-row policy gate is the thing that actually blocks release.

## Acceptance criteria
- the required retention-delete gate passes on protected rows
- release records approval before merge
- the checklist points reviewers at the real merge blocker
