### PR TITLE
Normalize blank owners before review routing

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -24,7 +24,8 @@ SEVERITY_RANK = {
 
 
 def normalize_owner(owner: str) -> str:
-    cleaned = owner.strip().lower().replace(" ", "-")
+    cleaned = owner.strip().lower().replace(" ", "-").replace("_", "-")
+    cleaned = "-".join(part for part in cleaned.split("-") if part)
     return cleaned or "unassigned"
 
 


### PR DESCRIPTION
## Summary
- collapse owner separators before review routing
- keep empty owner values on the existing `unassigned` path

## Context
Incident handoff entries have been arriving with padded or underscored owner names, which pushes simple routing cases into manual cleanup.

## Acceptance criteria
- padded, underscored, and repeated separators normalize consistently
- blank owners still route to `unassigned`
