### PR TITLE
Add fallback owner before escalation handoff

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -24,8 +24,16 @@ SEVERITY_RANK = {
 
 
 def normalize_owner(owner: str) -> str:
-    cleaned = owner.strip().lower().replace(" ", "-")
+    cleaned = owner.strip().lower().replace(" ", "-").replace("_", "-")
+    cleaned = "-".join(part for part in cleaned.split("-") if part)
     return cleaned or "unassigned"
+
+
+def owner_review_path(owner: str) -> str:
+    normalized_owner = normalize_owner(owner)
+    if normalized_owner == "unassigned":
+        return "engineering-ops"
+    return normalized_owner
 
 
 def highest_severity(signals: Iterable[OperationSignal]) -> str:


### PR DESCRIPTION
## Summary
- normalize owner separators before handoff
- route `unassigned` entries to the engineering-ops review path

## Context
Supersedes #100. This branch covers the same blank-owner normalization path and adds the escalation handoff Priya asked for, so I would rather keep one branch moving.

## Acceptance criteria
- owner normalization stays consistent for padded and underscored names
- blank owners still read as `unassigned`
- escalation gets a clear fallback review path before handoff
