### PR TITLE
Bump cryptography from 42.0.5 to 43.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyyaml==6.0.1
+typing-extensions==4.11.0
+cryptography==43.0.0


### PR DESCRIPTION
## Summary
- update the cryptography pin from 42.0.5 to 43.0.0

## Context
This is still a dependency bump, but it crosses a meaningful version boundary on the runtime path used by signed token handling. Please keep it separate from the weekly batch until Security and release have looked at the compatibility surface.

## Acceptance criteria
- Security review covers malformed, expired, and rotated-key replay cases
- compatibility notes are attached before release batching
- current-head CI is clean before merge
