### PR TITLE
EXP-116 Fix owner slug normalization

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Iterable
@@ -22,9 +23,11 @@ SEVERITY_RANK = {
     "critical": 4,
 }
 
+OWNER_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
 
 def normalize_owner(owner: str) -> str:
-    cleaned = owner.strip().lower().replace(" ", "-")
+    cleaned = OWNER_SLUG_RE.sub("-", owner.strip().lower()).strip("-")
     return cleaned or "unassigned"
 
 

--- a/tests/test_owner_normalization_edges.py
+++ b/tests/test_owner_normalization_edges.py
@@ -7,3 +7,11 @@ def test_owner_normalization_trims_and_lowercases():
 
 def test_owner_normalization_keeps_existing_slug():
     assert normalize_owner("platform-ops") == "platform-ops"
+
+
+def test_owner_normalization_collapses_duplicate_separators():
+    assert normalize_owner("Release   Ops___Primary") == "release-ops-primary"
+
+
+def test_owner_normalization_strips_punctuation_edges():
+    assert normalize_owner("!Platform Ops?") == "platform-ops"


### PR DESCRIPTION
## Summary
- Fix `normalize_owner` to collapse punctuation, underscores, and duplicate separators into stable slugs.
- Add regression tests for duplicate separators and punctuation boundaries.

Linear: https://linear.app/expertmicro1fernandomano/issue/EXP-116/normalize-owner-slugs-with-punctuation-and-duplicate-separators

## Verification
- `PYTHONPATH=/tmp/TC1 UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest`