### PR TITLE
EXP-118 Group operation signals by normalized owner

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -16,6 +16,13 @@ class OperationSignal:
     observed_at: datetime
 
 
+@dataclass(frozen=True)
+class ReleaseMarker:
+    version: str
+    channel: str
+    observed_at: datetime
+
+
 SEVERITY_RANK = {
     "low": 1,
     "medium": 2,
@@ -24,6 +31,7 @@ SEVERITY_RANK = {
 }
 
 OWNER_SLUG_RE = re.compile(r"[^a-z0-9]+")
+RELEASE_MARKER_TIMESTAMP_FORMAT = "%Y%m%d%H%M"
 
 
 def normalize_owner(owner: str) -> str:
@@ -43,6 +51,24 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
 
 
 def build_release_marker(version: str, channel: str) -> str:
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+    timestamp = datetime.now(timezone.utc).strftime(RELEASE_MARKER_TIMESTAMP_FORMAT)
     normalized_channel = channel.strip().lower() or "internal"
     return f"{version}-{normalized_channel}-{timestamp}"
+
+
+def parse_release_marker(marker: str) -> ReleaseMarker:
+    parts = marker.rsplit("-", maxsplit=2)
+    if len(parts) != 3 or not all(parts):
+        raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'")
+
+    version, channel, timestamp = parts
+    try:
+        observed_at = datetime.strptime(timestamp, RELEASE_MARKER_TIMESTAMP_FORMAT)
+    except ValueError as exc:
+        raise ValueError("release marker timestamp must use YYYYMMDDHHMM") from exc
+
+    return ReleaseMarker(
+        version=version,
+        channel=channel,
+        observed_at=observed_at.replace(tzinfo=timezone.utc),
+    )

--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -50,6 +50,13 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
     return severity
 
 
+def group_signals_by_owner(signals: Iterable[OperationSignal]) -> dict[str, list[OperationSignal]]:
+    grouped: dict[str, list[OperationSignal]] = {}
+    for signal in signals:
+        grouped.setdefault(normalize_owner(signal.owner), []).append(signal)
+    return grouped
+
+
 def build_release_marker(version: str, channel: str) -> str:
     timestamp = datetime.now(timezone.utc).strftime(RELEASE_MARKER_TIMESTAMP_FORMAT)
     normalized_channel = channel.strip().lower() or "internal"

--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Iterable
@@ -22,9 +23,11 @@ SEVERITY_RANK = {
     "critical": 4,
 }
 
+OWNER_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
 
 def normalize_owner(owner: str) -> str:
-    cleaned = owner.strip().lower().replace(" ", "-")
+    cleaned = OWNER_SLUG_RE.sub("-", owner.strip().lower()).strip("-")
     return cleaned or "unassigned"
 
 

--- a/tests/test_owner_normalization_edges.py
+++ b/tests/test_owner_normalization_edges.py
@@ -7,3 +7,11 @@ def test_owner_normalization_trims_and_lowercases():
 
 def test_owner_normalization_keeps_existing_slug():
     assert normalize_owner("platform-ops") == "platform-ops"
+
+
+def test_owner_normalization_collapses_duplicate_separators():
+    assert normalize_owner("Release   Ops___Primary") == "release-ops-primary"
+
+
+def test_owner_normalization_strips_punctuation_edges():
+    assert normalize_owner("!Platform Ops?") == "platform-ops"

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -2,7 +2,13 @@ from datetime import datetime, timezone
 
 import pytest
 
-from src.tc1_service import OperationSignal, highest_severity, normalize_owner, parse_release_marker
+from src.tc1_service import (
+    OperationSignal,
+    group_signals_by_owner,
+    highest_severity,
+    normalize_owner,
+    parse_release_marker,
+)
 
 
 def test_normalize_owner_falls_back_to_unassigned():
@@ -39,3 +45,16 @@ def test_parse_release_marker_rejects_malformed_marker():
 def test_parse_release_marker_rejects_invalid_timestamp():
     with pytest.raises(ValueError, match="timestamp"):
         parse_release_marker("2026.05.25-internal-202613011200")
+
+
+def test_group_signals_by_owner_normalizes_and_preserves_order():
+    first = OperationSignal("docs-drift", "medium", "Platform Ops", datetime.now(timezone.utc))
+    second = OperationSignal("flake", "low", "platform_ops", datetime.now(timezone.utc))
+    third = OperationSignal("unowned", "high", "   ", datetime.now(timezone.utc))
+
+    grouped = group_signals_by_owner([first, second, third])
+
+    assert grouped == {
+        "platform-ops": [first, second],
+        "unassigned": [third],
+    }

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -34,3 +34,8 @@ def test_parse_release_marker_returns_structured_fields():
 def test_parse_release_marker_rejects_malformed_marker():
     with pytest.raises(ValueError, match="release marker"):
         parse_release_marker("not-a-marker")
+
+
+def test_parse_release_marker_rejects_invalid_timestamp():
+    with pytest.raises(ValueError, match="timestamp"):
+        parse_release_marker("2026.05.25-internal-202613011200")

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 
-from src.tc1_service import OperationSignal, highest_severity, normalize_owner
+import pytest
+
+from src.tc1_service import OperationSignal, highest_severity, normalize_owner, parse_release_marker
 
 
 def test_normalize_owner_falls_back_to_unassigned():
@@ -19,3 +21,16 @@ def test_highest_severity_returns_largest_rank():
     ]
 
     assert highest_severity(signals) == "critical"
+
+
+def test_parse_release_marker_returns_structured_fields():
+    marker = parse_release_marker("2026.05.25-internal-202605251630")
+
+    assert marker.version == "2026.05.25"
+    assert marker.channel == "internal"
+    assert marker.observed_at == datetime(2026, 5, 25, 16, 30, tzinfo=timezone.utc)
+
+
+def test_parse_release_marker_rejects_malformed_marker():
+    with pytest.raises(ValueError, match="release marker"):
+        parse_release_marker("not-a-marker")


### PR DESCRIPTION
## Summary
- Add `group_signals_by_owner` to bucket operation signals by normalized owner key.
- Preserve each owner bucket's input order.
- Cover mixed owner spellings and blank owner fallback.

Linear: https://linear.app/expertmicro1fernandomano/issue/EXP-118/group-operation-signals-by-normalized-owner

## Verification
- `PYTHONPATH=/tmp/TC1 UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest`