### PR TITLE
Apply mute preferences in weekly digest builder

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Iterable, Mapping, Sequence
 
 
 @dataclass(frozen=True)
@@ -21,6 +21,13 @@ class ReleaseMarker:
     version: str
     channel: str
     observed_at: datetime
+
+
+@dataclass(frozen=True)
+class WeeklyDigestProject:
+    project_id: str
+    project_name: str
+    updates: tuple[str, ...]
 
 
 SEVERITY_RANK = {
@@ -55,6 +62,25 @@ def group_signals_by_owner(signals: Iterable[OperationSignal]) -> dict[str, list
     for signal in signals:
         grouped.setdefault(normalize_owner(signal.owner), []).append(signal)
     return grouped
+
+
+def build_weekly_digest_sections(
+    projects: Sequence[WeeklyDigestProject],
+    muted_projects: Mapping[str, bool] | None = None,
+) -> list[dict[str, object]]:
+    preferences = muted_projects or {}
+    active_projects = [
+        project for project in projects if not preferences.get(project.project_id, False)
+    ]
+
+    return [
+        {
+            "project_id": project.project_id,
+            "title": project.project_name,
+            "updates": list(project.updates),
+        }
+        for project in active_projects
+    ]
 
 
 def build_release_marker(version: str, channel: str) -> str:


### PR DESCRIPTION
Updates the weekly digest builder so muted project preferences are applied before digest sections are assembled.

Manual validation:
- Created a workspace with one muted project and one active project.
- Confirmed the muted project was excluded from the generated digest preview.
- Confirmed regular in-app notifications were not affected.

Notes:
- The digest builder already has indirect coverage through existing rendering paths.
- This change focuses on preference filtering before the email payload is assembled.