### PR TITLE
Increase export worker retry timeout

### DIFF
--- a/config/operations.yml
+++ b/config/operations.yml
@@ -15,6 +15,10 @@ ci:
     - repository-baseline
   flaky_test_budget: 2
 
+export:
+  worker_retry_timeout_seconds: 900
+  stalled_after_attempts: 3
+
 ownership:
   default_owner: platform-ops
   fallback_triage: engineering-ops


### PR DESCRIPTION
Increases the export worker retry timeout so large workspace exports have enough time to acquire a worker before being marked as stalled.

Validation:
- Verified in staging with a large export job.
- Confirmed smaller export jobs still complete normally.
- Confirmed the change only affects the retry window and does not alter export contents.