### PR TITLE
Reject short release marker timestamps

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -69,6 +69,9 @@ def parse_release_marker(marker: str) -> ReleaseMarker:
         raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'")
 
     version, channel, timestamp = parts
+    if not re.fullmatch(r"\d{12}", timestamp):
+        raise ValueError("release marker timestamp must use YYYYMMDDHHMM")
+
     try:
         observed_at = datetime.strptime(timestamp, RELEASE_MARKER_TIMESTAMP_FORMAT)
     except ValueError as exc:

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -47,6 +47,11 @@ def test_parse_release_marker_rejects_invalid_timestamp():
         parse_release_marker("2026.05.25-internal-202613011200")
 
 
+def test_parse_release_marker_rejects_short_timestamp():
+    with pytest.raises(ValueError, match="timestamp"):
+        parse_release_marker("2026.05.25-internal-20260525163")
+
+
 def test_group_signals_by_owner_normalizes_and_preserves_order():
     first = OperationSignal("docs-drift", "medium", "Platform Ops", datetime.now(timezone.utc))
     second = OperationSignal("flake", "low", "platform_ops", datetime.now(timezone.utc))


### PR DESCRIPTION
Tightens release marker timestamp parsing so shortened timestamp tokens are rejected.

Test coverage:
- Added regression coverage for an 11-digit timestamp token.
- Confirmed existing parse tests still cover malformed markers and invalid calendar values.