### PR TITLE
Refresh release marker rollout notes

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,7 @@
 # Release checklist
 
 - Confirm release marker generation.
+- Confirm marker channels copied from support notes use the approved lowercase slug.
 - Check incident-routing configuration.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.


### PR DESCRIPTION
Refreshes the release checklist wording so copied channel values and rollout notes stay clear during cutoff.

No runtime behavior changes.

Validation:
- Reviewed the updated checklist in context.
- Confirmed no service code or configuration changed.