### PR TITLE
Keep unassigned owners on the fallback triage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ python -m pytest
 ## Triage notes
 
 Evaluate PRs from the current diff, check status, review discussion, linked work items, and release context. When a change is blocked, leave the blocker in the PR thread and keep any external tracker aligned with the current owner and next action.
+
+When a handoff caller needs a page-ready owner for blank owner values, pass the configured fallback triage owner into owner grouping instead of leaving the handoff on the unassigned path.

--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -50,10 +50,17 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
     return severity
 
 
-def group_signals_by_owner(signals: Iterable[OperationSignal]) -> dict[str, list[OperationSignal]]:
+def group_signals_by_owner(
+    signals: Iterable[OperationSignal],
+    *,
+    fallback_owner: str | None = None,
+) -> dict[str, list[OperationSignal]]:
     grouped: dict[str, list[OperationSignal]] = {}
     for signal in signals:
-        grouped.setdefault(normalize_owner(signal.owner), []).append(signal)
+        owner = normalize_owner(signal.owner)
+        if owner == "unassigned" and fallback_owner:
+            owner = normalize_owner(fallback_owner)
+        grouped.setdefault(owner, []).append(signal)
     return grouped
 
 


### PR DESCRIPTION
Extends owner grouping so handoff callers can keep blank-owner signals on the fallback triage path without changing existing grouping defaults.

Validation:
- Manually checked a blank-owner signal with `fallback_owner="engineering-ops"`.
- Existing owner normalization coverage still exercises the unassigned path.
- I did not add a targeted assertion for the new grouping option yet.