### PR TITLE
Normalize release marker channels from support notes

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -59,7 +59,7 @@ def group_signals_by_owner(signals: Iterable[OperationSignal]) -> dict[str, list
 
 def build_release_marker(version: str, channel: str) -> str:
     timestamp = datetime.now(timezone.utc).strftime(RELEASE_MARKER_TIMESTAMP_FORMAT)
-    normalized_channel = channel.strip().lower() or "internal"
+    normalized_channel = OWNER_SLUG_RE.sub("-", channel.strip().lower()).strip("-") or "internal"
     return f"{version}-{normalized_channel}-{timestamp}"
 
 

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.tc1_service import (
     OperationSignal,
+    build_release_marker,
     group_signals_by_owner,
     highest_severity,
     normalize_owner,
@@ -27,6 +28,12 @@ def test_highest_severity_returns_largest_rank():
     ]
 
     assert highest_severity(signals) == "critical"
+
+
+def test_build_release_marker_normalizes_channel_values_from_support_notes():
+    marker = build_release_marker("2026.05.25", "Internal Ops___Primary")
+
+    assert marker.startswith("2026.05.25-internal-ops-primary-")
 
 
 def test_parse_release_marker_returns_structured_fields():


### PR DESCRIPTION
Normalizes release marker channels copied from support notes before marker assembly so copied values keep a stable lowercase slug.

Test coverage:
- Added coverage for a support-note channel with spaces and underscores.
- Existing marker parsing tests still cover the normal marker shape.

Notes:
- I manually checked the default `internal` marker path during cutoff prep.
- I did not add a separate blank-channel assertion in this PR.