### PR TITLE
Round-trip normalized release markers in parser

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -64,11 +64,17 @@ def build_release_marker(version: str, channel: str) -> str:
 
 
 def parse_release_marker(marker: str) -> ReleaseMarker:
-    parts = marker.rsplit("-", maxsplit=2)
-    if len(parts) != 3 or not all(parts):
-        raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'")
+    try:
+        prefix, timestamp = marker.rsplit("-", maxsplit=1)
+        version, channel = prefix.split("-", maxsplit=1)
+    except ValueError as exc:
+        raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'") from exc
 
-    version, channel, timestamp = parts
+    if not all((version, channel, timestamp)):
+        raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'")
+    if len(timestamp) != 12:
+        raise ValueError("release marker timestamp must use YYYYMMDDHHMM")
+
     try:
         observed_at = datetime.strptime(timestamp, RELEASE_MARKER_TIMESTAMP_FORMAT)
     except ValueError as exc:

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -44,6 +44,14 @@ def test_parse_release_marker_returns_structured_fields():
     assert marker.observed_at == datetime(2026, 5, 25, 16, 30, tzinfo=timezone.utc)
 
 
+def test_parse_release_marker_round_trips_normalized_channels():
+    marker = build_release_marker("2026.05.25", "Internal Ops___Primary")
+    parsed = parse_release_marker(marker)
+
+    assert parsed.version == "2026.05.25"
+    assert parsed.channel == "internal-ops-primary"
+
+
 def test_parse_release_marker_rejects_malformed_marker():
     with pytest.raises(ValueError, match="release marker"):
         parse_release_marker("not-a-marker")
@@ -52,6 +60,11 @@ def test_parse_release_marker_rejects_malformed_marker():
 def test_parse_release_marker_rejects_invalid_timestamp():
     with pytest.raises(ValueError, match="timestamp"):
         parse_release_marker("2026.05.25-internal-202613011200")
+
+
+def test_parse_release_marker_rejects_short_timestamp():
+    with pytest.raises(ValueError, match="timestamp"):
+        parse_release_marker("2026.05.25-internal-20260525163")
 
 
 def test_group_signals_by_owner_normalizes_and_preserves_order():


### PR DESCRIPTION
Lets the release marker parser round-trip markers whose channel segment is already normalized with hyphens.

Test coverage:
- Added a round-trip parse case for normalized copied-channel markers.
- Added regression coverage for an 11-digit timestamp token.
- Confirmed malformed-marker and invalid-calendar coverage still pass.

Notes:
- This follows the channel normalization work so copied support-note channels can be parsed cleanly.
- The default internal fallback path is unchanged.