### PR TITLE
Use fallback triage owner for blank handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ python -m pytest
 
 ## Triage notes
 
-Evaluate PRs from the current diff, check status, review discussion, linked work items, and release context. When a change is blocked, leave the blocker in the PR thread and keep any external tracker aligned with the current owner and next action.
+Evaluate PRs from the current diff, check status, review discussion, linked work items, and release context. When a handoff arrives without an owner, route it through the fallback triage owner for review before release escalation. When a change is blocked, leave the blocker in the PR thread and keep any external tracker aligned with the current owner and next action.

--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -50,10 +50,20 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
     return severity
 
 
-def group_signals_by_owner(signals: Iterable[OperationSignal]) -> dict[str, list[OperationSignal]]:
+def group_signals_by_owner(
+    signals: Iterable[OperationSignal],
+    *,
+    fallback_owner: str | None = None,
+) -> dict[str, list[OperationSignal]]:
     grouped: dict[str, list[OperationSignal]] = {}
+    normalized_fallback_owner = normalize_owner(fallback_owner) if fallback_owner else None
+
     for signal in signals:
-        grouped.setdefault(normalize_owner(signal.owner), []).append(signal)
+        owner_key = normalize_owner(signal.owner)
+        if owner_key == "unassigned" and normalized_fallback_owner is not None:
+            owner_key = normalized_fallback_owner
+        grouped.setdefault(owner_key, []).append(signal)
+
     return grouped
 
 


### PR DESCRIPTION
Routes blank-owner handoffs through a fallback triage owner when handoff callers provide one, while preserving the existing `unassigned` default for callers that do not.

Validation:
- Manually checked a blank-owner signal with `fallback_owner="engineering-ops"`.
- Existing owner normalization coverage still exercises the default unassigned path.
- I did not add a targeted assertion for the new fallback option yet.