### PR TITLE
Cover fallback triage grouping behavior

### DIFF
--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -78,3 +78,19 @@ def test_group_signals_by_owner_normalizes_and_preserves_order():
         "platform-ops": [first, second],
         "unassigned": [third],
     }
+
+
+def test_group_signals_by_owner_uses_fallback_owner_for_blank_handoffs():
+    signal = OperationSignal("handoff", "high", "   ", datetime.now(timezone.utc))
+
+    grouped = group_signals_by_owner([signal], fallback_owner="engineering-ops")
+
+    assert grouped == {"engineering-ops": [signal]}
+
+
+def test_group_signals_by_owner_keeps_default_unassigned_path_without_fallback():
+    signal = OperationSignal("handoff", "high", "   ", datetime.now(timezone.utc))
+
+    grouped = group_signals_by_owner([signal])
+
+    assert grouped == {"unassigned": [signal]}


### PR DESCRIPTION
Adds direct regression coverage for blank-owner fallback grouping and the unchanged default unassigned path.

Test coverage:
- Added a direct fallback-owner assertion for blank handoffs.
- Added a direct assertion that callers without a fallback owner still group blanks under `unassigned`.