### PR TITLE
Extend rerun window for mirror timeouts

### DIFF
--- a/config/operations.yml
+++ b/config/operations.yml
@@ -13,7 +13,7 @@ ci:
   required_jobs:
     - unit-tests
     - repository-baseline
-  flaky_test_budget: 2
+  flaky_test_budget: 3
 
 ownership:
   default_owner: platform-ops


### PR DESCRIPTION
Extends the mirror-timeout rerun window from 2 to 3 so accepted same-head reruns stay inside the normal review path during artifact mirror noise.

Validation:
- Confirmed the current-head smoke path stayed on the same branch after an accepted rerun.
- This is a configuration-only change.
- Release wants one production cycle with the raised budget before the verification note is treated as complete.