### PR TITLE
Clarify release marker cutoff notes

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,8 @@
 # Release checklist
 
-- Confirm release marker generation.
+- Confirm release marker generation before cutoff.
+- When a channel is copied from support notes, verify the generated marker keeps the normalized slug.
+- Confirm the default `internal` marker still holds when no channel is supplied.
 - Check incident-routing configuration.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.


### PR DESCRIPTION
Clarifies release checklist wording around copied channel values and cutoff-time marker checks.

No runtime behavior changes.

Validation:
- Reviewed the updated checklist in context.
- Confirmed no service code or configuration changed.