### PR TITLE
Sort handoff summary owners for stable notes

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -84,7 +84,7 @@ def summarize_signals_for_handoff(
 
     return HandoffSummary(
         highest_severity=highest_severity(signal_list),
-        owners=tuple(grouped),
+        owners=tuple(sorted(grouped)),
         signal_count=len(signal_list),
     )
 


### PR DESCRIPTION
Sorts owners in handoff summaries so release notes stay stable across batches copied from support handoffs.

Validation:
- Checked two sample handoff batches with the same owners in different arrival order.
- Existing grouping behavior is unchanged.