### PR TITLE
Raise stale review threshold during cutover

### DIFF
--- a/config/operations.yml
+++ b/config/operations.yml
@@ -5,7 +5,7 @@ release:
   rollback_owner: release-management
 
 review:
-  stale_after_days: 4
+  stale_after_days: 5
   required_reviewers: 2
   escalation_channel: engineering-ops
 


### PR DESCRIPTION
Raises the stale review threshold from 4 to 5 during cutover week so same-head follow-up pushes do not fall into stale review too early.

Validation:
- Checked the current review queue after the threshold change.
- This is configuration-only.