### PR TITLE
Clarify cutover handoff checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,7 @@
 - When a channel is copied from support notes, verify the generated marker keeps the normalized slug.
 - Confirm the default `internal` marker still holds when no channel is supplied.
 - Check incident-routing configuration.
+- During cutover handoff, keep release-note owners and review-queue wording aligned before cutoff.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
 - Tag unresolved risks before release cutoff.


### PR DESCRIPTION
Clarifies the cutover handoff checklist so release notes and review queue checks use the same owner and stale-window language.

No runtime behavior changes.

Validation:
- Reviewed the checklist wording against today's cutover handoff.
- Confirmed no service code or configuration changed.