### PR TITLE
Add tuple fallback helper coverage for handoff batches

### DIFF
--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -114,6 +114,14 @@ def test_group_signals_by_owner_uses_fallback_owner_for_generator_handoffs():
     assert grouped == {"engineering-ops": [signal]}
 
 
+def test_group_signals_by_owner_uses_fallback_owner_for_tuple_handoffs():
+    signal = OperationSignal("handoff", "high", "   ", datetime.now(timezone.utc))
+
+    grouped = group_signals_by_owner((signal,), fallback_owner="Engineering Ops")
+
+    assert grouped == {"engineering-ops": [signal]}
+
+
 def test_group_signals_by_owner_keeps_default_unassigned_path_without_fallback():
     signal = OperationSignal("handoff", "high", "   ", datetime.now(timezone.utc))
 


### PR DESCRIPTION
Adds another direct helper-level regression around blank-owner handoff batches used by release-note paths.

Test coverage:
- Added a tuple batch example for `group_signals_by_owner(..., fallback_owner=...)`.
- Existing grouped-owner and generator coverage stays intact.
- I did not add a wrapper-level `summarize_signals_for_handoff` example in this PR.