### PR TITLE
Normalize copied severity labels before handoff summary ranking

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -50,10 +50,11 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
     rank = 0
     severity = "low"
     for signal in signals:
-        signal_rank = SEVERITY_RANK.get(signal.severity, 0)
+        normalized_severity = signal.severity.strip().lower()
+        signal_rank = SEVERITY_RANK.get(normalized_severity, 0)
         if signal_rank > rank:
             rank = signal_rank
-            severity = signal.severity
+            severity = normalized_severity
     return severity
 
 

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -42,6 +42,15 @@ def test_highest_severity_handles_generator_batches():
     assert highest_severity(signals) == "high"
 
 
+def test_highest_severity_normalizes_copied_padded_labels():
+    signals = [
+        OperationSignal("handoff", " HIGH ", "release", datetime.now(timezone.utc)),
+        OperationSignal("docs-drift", "medium", "docs", datetime.now(timezone.utc)),
+    ]
+
+    assert highest_severity(signals) == "high"
+
+
 def test_build_release_marker_normalizes_channel_values_from_support_notes():
     marker = build_release_marker("2026.05.25", "Internal Ops___Primary")
 


### PR DESCRIPTION
Normalizes severity labels copied from incident notes so values like ` HIGH ` stay on the expected handoff path.

Validation:
- Spot-checked a support-note payload with padded severity text.
- Existing severity-ranking tests still cover the normal low/medium/high/critical ordering.
- I did not add a targeted assertion for copied padded severity labels yet.