### PR TITLE
Allow release markers to fall back when the channel is missing

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -89,9 +89,13 @@ def summarize_signals_for_handoff(
     )
 
 
-def build_release_marker(version: str, channel: str) -> str:
+def build_release_marker(version: str, channel: str | None) -> str:
     timestamp = datetime.now(timezone.utc).strftime(RELEASE_MARKER_TIMESTAMP_FORMAT)
-    normalized_channel = OWNER_SLUG_RE.sub("-", channel.strip().lower()).strip("-") or "internal"
+    normalized_channel = (
+        OWNER_SLUG_RE.sub("-", channel.strip().lower()).strip("-")
+        if channel is not None
+        else ""
+    ) or "internal"
     return f"{version}-{normalized_channel}-{timestamp}"
 
 


### PR DESCRIPTION
Accepts release payloads that omit the channel field and keeps marker generation on the default `internal` path instead of raising on `None`.

Validation:
- Cut a local marker from a payload with `channel=None`.
- Existing blank-channel and parser tests still cover the normal marker path.
- I did not add a direct missing-channel assertion in this PR.