### PR TITLE
Trim surrounding whitespace before release marker parsing

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -96,6 +96,8 @@ def build_release_marker(version: str, channel: str) -> str:
 
 
 def parse_release_marker(marker: str) -> ReleaseMarker:
+    marker = marker.strip()
+
     try:
         prefix, timestamp = marker.rsplit("-", maxsplit=1)
         version, channel = prefix.split("-", maxsplit=1)

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -70,6 +70,14 @@ def test_parse_release_marker_round_trips_normalized_channels():
     assert parsed.channel == "internal-ops-primary"
 
 
+def test_parse_release_marker_trims_surrounding_whitespace():
+    marker = parse_release_marker("  2026.05.25-internal-202605251630\n")
+
+    assert marker.version == "2026.05.25"
+    assert marker.channel == "internal"
+    assert marker.observed_at == datetime(2026, 5, 25, 16, 30, tzinfo=timezone.utc)
+
+
 def test_parse_release_marker_rejects_malformed_marker():
     with pytest.raises(ValueError, match="release marker"):
         parse_release_marker("not-a-marker")


### PR DESCRIPTION
Trims copied marker strings before parsing so release notes pasted from chat still round-trip cleanly.

Test coverage:
- Added a direct regression for a marker with surrounding spaces and a trailing newline.
- Existing normalized-channel, malformed-marker, invalid-calendar, and short-timestamp coverage stays intact.