### PR TITLE
Ignore newline noise around copied release markers

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -96,6 +96,8 @@ def build_release_marker(version: str, channel: str) -> str:
 
 
 def parse_release_marker(marker: str) -> ReleaseMarker:
+    marker = marker.strip()
+
     try:
         prefix, timestamp = marker.rsplit("-", maxsplit=1)
         version, channel = prefix.split("-", maxsplit=1)

--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -70,6 +70,14 @@ def test_parse_release_marker_round_trips_normalized_channels():
     assert parsed.channel == "internal-ops-primary"
 
 
+def test_parse_release_marker_trims_copied_marker_noise():
+    marker = parse_release_marker("  2026.05.25-internal-202605251630\n")
+
+    assert marker.version == "2026.05.25"
+    assert marker.channel == "internal"
+    assert marker.observed_at == datetime(2026, 5, 25, 16, 30, tzinfo=timezone.utc)
+
+
 def test_parse_release_marker_rejects_malformed_marker():
     with pytest.raises(ValueError, match="release marker"):
         parse_release_marker("not-a-marker")


### PR DESCRIPTION
Trims pasted marker strings before parsing so copied values from support notes tolerate surrounding whitespace and trailing newlines.

Test coverage:
- Added a direct copied-marker trim regression.
- Existing malformed-marker, invalid-calendar, short-timestamp, and normalized-channel cases stay intact.