### PR TITLE
Accept omitted channels in release marker builder

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -89,9 +89,10 @@ def summarize_signals_for_handoff(
     )
 
 
-def build_release_marker(version: str, channel: str) -> str:
+def build_release_marker(version: str, channel: str | None) -> str:
     timestamp = datetime.now(timezone.utc).strftime(RELEASE_MARKER_TIMESTAMP_FORMAT)
-    normalized_channel = OWNER_SLUG_RE.sub("-", channel.strip().lower()).strip("-") or "internal"
+    channel_text = channel or ""
+    normalized_channel = OWNER_SLUG_RE.sub("-", channel_text.strip().lower()).strip("-") or "internal"
     return f"{version}-{normalized_channel}-{timestamp}"
 
 


### PR DESCRIPTION
Accepts deploy-note payloads that omit the channel field and keeps marker generation on the default `internal` path instead of raising on empty upstream data.

Validation:
- Cut a local marker from a payload with `channel=None`.
- Existing copied-channel and blank-channel coverage still exercise the common marker path.