### PR TITLE
Cover copied-severity helper cases for handoffs

### DIFF
--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -42,6 +42,15 @@ def test_highest_severity_handles_generator_batches():
     assert highest_severity(signals) == "high"
 
 
+def test_highest_severity_normalizes_copied_labels():
+    signals = [
+        OperationSignal("handoff", " HIGH ", "release", datetime.now(timezone.utc)),
+        OperationSignal("docs-drift", "medium", "docs", datetime.now(timezone.utc)),
+    ]
+
+    assert highest_severity(signals) == "high"
+
+
 def test_build_release_marker_normalizes_channel_values_from_support_notes():
     marker = build_release_marker("2026.05.25", "Internal Ops___Primary")
 


### PR DESCRIPTION
Adds narrow helper-level coverage for copied severity labels on top of the ranking change.

Test coverage:
- Added a direct `highest_severity` copied-label assertion.
- Existing owner-grouping coverage stays intact.