### PR TITLE
Clarify copied-severity checks in the release checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -5,6 +5,7 @@
 - Confirm the default `internal` marker still holds when no channel is supplied.
 - Check incident-routing configuration.
 - During cutover handoff, keep release-note owners and review-queue wording aligned before cutoff.
+- Verify copied handoff severity text stays aligned with the release-note summary before cutoff.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
 - Tag unresolved risks before release cutoff.


### PR DESCRIPTION
Updates checklist wording so reviewers confirm copied severity text still lines up with release-note summary output.

No runtime behavior changes.

Validation:
- Reviewed the wording in context.
- Confirmed no service code changed.