### PR TITLE
Clarify prefixed marker checks in the release checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,6 +2,7 @@
 
 - Confirm release marker generation before cutoff.
 - When a channel is copied from support notes, verify the generated marker keeps the normalized slug.
+- When a marker is pasted back from release notes, confirm the copied label and spacing around the marker value do not change the parse path.
 - Confirm the default `internal` marker still holds when no channel is supplied.
 - Check incident-routing configuration.
 - During cutover handoff, keep release-note owners and review-queue wording aligned before cutoff.


### PR DESCRIPTION
Updates the release checklist wording so reviewers remember to spot-check markers pasted back from release notes with copied labels around the value.

No runtime behavior changes.

Validation:
- Reviewed the wording in context.
- Confirmed no service code changed.