### PR TITLE
Default omitted marker channels to internal during parse

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -98,9 +98,14 @@ def build_release_marker(version: str, channel: str) -> str:
 def parse_release_marker(marker: str) -> ReleaseMarker:
     try:
         prefix, timestamp = marker.rsplit("-", maxsplit=1)
-        version, channel = prefix.split("-", maxsplit=1)
     except ValueError as exc:
         raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'") from exc
+
+    if "-" in prefix:
+        version, channel = prefix.split("-", maxsplit=1)
+    else:
+        version = prefix
+        channel = "internal"
 
     if not all((version, channel, timestamp)):
         raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'")


### PR DESCRIPTION
Accepts older marker values that omit the channel token and keeps them on the default `internal` path during parsing.

Validation:
- Parsed a copied release note line without a channel token locally.
- Existing builder blank-channel and parser coverage still exercise the common marker shape.