### PR TITLE
Add tuple-batch helper coverage for handoff owners

### DIFF
--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -114,6 +114,18 @@ def test_group_signals_by_owner_uses_fallback_owner_for_generator_handoffs():
     assert grouped == {"engineering-ops": [signal]}
 
 
+def test_group_signals_by_owner_uses_fallback_owner_for_tuple_batches():
+    first = OperationSignal("handoff", "high", "   ", datetime.now(timezone.utc))
+    second = OperationSignal("paging", "medium", "Platform Ops", datetime.now(timezone.utc))
+
+    grouped = group_signals_by_owner((first, second), fallback_owner="release-ops")
+
+    assert grouped == {
+        "release-ops": [first],
+        "platform-ops": [second],
+    }
+
+
 def test_group_signals_by_owner_keeps_default_unassigned_path_without_fallback():
     signal = OperationSignal("handoff", "high", "   ", datetime.now(timezone.utc))
 


### PR DESCRIPTION
Adds another narrow helper-level assertion for tuple-backed handoff batches using `group_signals_by_owner(..., fallback_owner=...)`.

Test coverage:
- Added a direct tuple-batch helper example.
- Existing list and generator helper coverage stays intact.
- I did not add a wrapper-level `summarize_signals_for_handoff` example in this PR.