### PR TITLE
Clarify empty handoff checks in the release checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -5,6 +5,7 @@
 - Confirm the default `internal` marker still holds when no channel is supplied.
 - Check incident-routing configuration.
 - During cutover handoff, keep release-note owners and review-queue wording aligned before cutoff.
+- For empty release-note handoffs, confirm the fallback owner still appears in the summary.
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
 - Tag unresolved risks before release cutoff.


### PR DESCRIPTION
Updates the release checklist wording so reviewers keep empty release-note handoff summaries on the fallback path during cutoff.

No runtime behavior changes.

Validation:
- Reviewed the checklist wording in context.
- Confirmed no service code changed.