### PR TITLE
Default empty handoff summaries to the fallback owner

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -80,6 +80,13 @@ def summarize_signals_for_handoff(
     fallback_owner: str | None = None,
 ) -> HandoffSummary:
     signal_list = list(signals)
+    if not signal_list and fallback_owner:
+        return HandoffSummary(
+            highest_severity="low",
+            owners=(normalize_owner(fallback_owner),),
+            signal_count=0,
+        )
+
     grouped = group_signals_by_owner(signal_list, fallback_owner=fallback_owner)
 
     return HandoffSummary(


### PR DESCRIPTION
Keeps empty copied-note handoff summaries on the fallback triage path during release cutoff so the summary still exposes a deterministic owner.

Validation:
- Spot-checked an empty handoff payload with `fallback_owner="Engineering Ops"` locally.
- Existing owner normalization and summary behavior stayed unchanged for populated batches.