### PR TITLE
Cover empty handoff summaries with fallback owner

### DIFF
--- a/tests/test_tc1_service.py
+++ b/tests/test_tc1_service.py
@@ -9,6 +9,7 @@ from src.tc1_service import (
     highest_severity,
     normalize_owner,
     parse_release_marker,
+    summarize_signals_for_handoff,
 )
 
 
@@ -120,3 +121,11 @@ def test_group_signals_by_owner_keeps_default_unassigned_path_without_fallback()
     grouped = group_signals_by_owner([signal])
 
     assert grouped == {"unassigned": [signal]}
+
+
+def test_summarize_signals_for_handoff_keeps_fallback_owner_for_empty_batches():
+    summary = summarize_signals_for_handoff([], fallback_owner="Engineering Ops")
+
+    assert summary.highest_severity == "low"
+    assert summary.owners == ("engineering-ops",)
+    assert summary.signal_count == 0


### PR DESCRIPTION
Adds a direct summary-path regression on top of the empty-handoff fallback branch.

Test coverage:
- Covers an empty handoff batch with a mixed-case fallback owner.
- Asserts the summary keeps `low` severity, the normalized owner tuple, and a zero signal count.
- Existing helper-level owner coverage stays intact.