### PR TITLE
Skip blank copied handoff rows in summaries

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -79,7 +79,7 @@ def summarize_signals_for_handoff(
     *,
     fallback_owner: str | None = None,
 ) -> HandoffSummary:
-    signal_list = list(signals)
+    signal_list = [signal for signal in signals if signal.name.strip()]
     grouped = group_signals_by_owner(signal_list, fallback_owner=fallback_owner)
 
     return HandoffSummary(


### PR DESCRIPTION
Drops copied-note rows that only contain whitespace before handoff summaries are assembled so release-note noise does not inflate the summary count or owner list.

Validation:
- Spot-checked a copied note batch with one populated row and one blank row locally.
- Existing populated-batch summary behavior stayed unchanged.