### PR TITLE
Clarify handoff checklist wording for copied rows

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,3 +8,4 @@
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
 - Tag unresolved risks before release cutoff.
+- Confirm copied handoff rows do not leave an empty owner line in the release summary.


### PR DESCRIPTION
Copy-only release checklist clarification for copied handoff rows.

No runtime behavior changes.