### PR TITLE
Route empty handoff summaries to the fallback owner

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -81,6 +81,8 @@ def summarize_signals_for_handoff(
 ) -> HandoffSummary:
     signal_list = list(signals)
     grouped = group_signals_by_owner(signal_list, fallback_owner=fallback_owner)
+    if not signal_list and fallback_owner:
+        grouped = {normalize_owner(fallback_owner): []}
 
     return HandoffSummary(
         highest_severity=highest_severity(signal_list),


### PR DESCRIPTION
Routes empty handoff summaries to the configured fallback owner so release notes do not drop the owner line entirely.

Validation:
- Spot-checked one copied handoff batch locally.
- No direct wrapper regression was added in this PR.