### PR TITLE
Ignore blank copied rows before handoff summary grouping

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -79,7 +79,7 @@ def summarize_signals_for_handoff(
     *,
     fallback_owner: str | None = None,
 ) -> HandoffSummary:
-    signal_list = list(signals)
+    signal_list = [signal for signal in list(signals) if signal.name.strip() or signal.owner.strip()]
     grouped = group_signals_by_owner(signal_list, fallback_owner=fallback_owner)
 
     return HandoffSummary(


### PR DESCRIPTION
Ignores fully blank rows from copied handoff notes before summary grouping.

Manual validation:
- Pasted support notes with one blank spacer row into the local preview.
- Confirmed the empty row disappeared from the release-facing handoff summary.
- No targeted wrapper regression was added in this PR.