### PR TITLE
Accept omitted release marker channels during parse

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -102,8 +102,9 @@ def parse_release_marker(marker: str) -> ReleaseMarker:
     except ValueError as exc:
         raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'") from exc
 
-    if not all((version, channel, timestamp)):
+    if not version or not timestamp:
         raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'")
+    channel = channel or "internal"
     if len(timestamp) != 12:
         raise ValueError("release marker timestamp must use YYYYMMDDHHMM")
 


### PR DESCRIPTION
Allows copied release markers with an omitted channel segment to default to `internal` during parse.

Manual validation only:
- Checked one copied support-note marker with a blank channel cell.
- Direct omitted-channel parser coverage is still missing on this head.