### PR TITLE
Extend stale review window through cutover handoffs

### DIFF
--- a/config/operations.yml
+++ b/config/operations.yml
@@ -5,7 +5,7 @@ release:
   rollback_owner: release-management
 
 review:
-  stale_after_days: 5
+  stale_after_days: 6
   required_reviewers: 2
   escalation_channel: engineering-ops
 


### PR DESCRIPTION
Extends the stale review window through cutover handoffs so same-head follow-up pushes stay inside the normal review path.

Validation:
- One local queue spot-check on the current head.
- One production-cycle confirmation is still needed before release closeout.