### PR TITLE
Reject truncated copied markers during parse

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -104,7 +104,7 @@ def parse_release_marker(marker: str) -> ReleaseMarker:
 
     if not all((version, channel, timestamp)):
         raise ValueError("release marker must be '<version>-<channel>-<YYYYMMDDHHMM>'")
-    if len(timestamp) != 12:
+    if len(timestamp) != 13:
         raise ValueError("release marker timestamp must use YYYYMMDDHHMM")
 
     try:


### PR DESCRIPTION
Tightens the copied-marker timestamp guard before the release parser accepts a handoff note.

Current head is still red in CI on one round-trip parser case, so this is open for reconciliation before review continues.