### PR TITLE
Set support handoff escalation wording in the release checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,3 +8,4 @@
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
 - Tag unresolved risks before release cutoff.
+- Escalate support handoffs after 20 minutes if the release owner has not replied.


### PR DESCRIPTION
Updates release checklist escalation copy for support handoffs.

Support has not confirmed whether the threshold should be 20 or 30 minutes yet, so please hold review here until the sign-off lands.