### PR TITLE
Fix retry budget zero override

### DIFF
--- a/src/intake_service.py
+++ b/src/intake_service.py
@@ -14,7 +14,7 @@ class HandoffRow(TypedDict):
 
 def resolve_retry_budget(requested: int | None, default: int) -> int:
     """Return the configured retry count unless a request overrides it."""
-    return requested or default
+    return default if requested is None else requested
 
 
 def filter_handoff_rows(rows: Iterable[HandoffRow]) -> list[HandoffRow]:

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -9,6 +9,10 @@ def test_retry_budget_uses_default_when_omitted() -> None:
     assert resolve_retry_budget(None, 3) == 3
 
 
+def test_retry_budget_preserves_zero_override() -> None:
+    assert resolve_retry_budget(0, 3) == 0
+
+
 def test_retry_budget_accepts_positive_override() -> None:
     assert resolve_retry_budget(2, 3) == 2
 


### PR DESCRIPTION
## Summary

Fixes [EXP-184](https://linear.app/expertmicro1fernandomano/issue/EXP-184/fix-retry-budget-zero-override-in-intake-service).

- Preserve explicit retry budget overrides of `0`.
- Keep `None` falling back to the workspace default.
- Add a regression assertion for the zero override path.

## Validation

- `python3 -c "from src.intake_service import resolve_retry_budget; assert resolve_retry_budget(0, 3) == 0; assert resolve_retry_budget(None, 3) == 3; assert resolve_retry_budget(2, 3) == 2"`
- Full local `python3 -m pytest` was not available because pytest is not installed in this local clone; GitHub Actions should run the suite.