### PR TITLE
Add minimum severity handoff filter

### DIFF
--- a/src/intake_service.py
+++ b/src/intake_service.py
@@ -34,8 +34,10 @@ def filter_handoff_rows(
     row_list = list(rows)
     if minimum_severity is None:
         return row_list
+    if minimum_severity not in SEVERITY_RANK:
+        raise ValueError(f"unknown minimum severity: {minimum_severity}")
 
-    minimum_rank = SEVERITY_RANK.get(minimum_severity, 0)
+    minimum_rank = SEVERITY_RANK[minimum_severity]
     return [
         row
         for row in row_list

--- a/src/intake_service.py
+++ b/src/intake_service.py
@@ -12,14 +12,35 @@ class HandoffRow(TypedDict):
     summary: str
 
 
+SEVERITY_RANK = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+
 def resolve_retry_budget(requested: int | None, default: int) -> int:
     """Return the configured retry count unless a request overrides it."""
     return default if requested is None else requested
 
 
-def filter_handoff_rows(rows: Iterable[HandoffRow]) -> list[HandoffRow]:
+def filter_handoff_rows(
+    rows: Iterable[HandoffRow],
+    *,
+    minimum_severity: str | None = None,
+) -> list[HandoffRow]:
     """Return handoff rows in the order copied from support notes."""
-    return list(rows)
+    row_list = list(rows)
+    if minimum_severity is None:
+        return row_list
+
+    minimum_rank = SEVERITY_RANK.get(minimum_severity, 0)
+    return [
+        row
+        for row in row_list
+        if SEVERITY_RANK.get(row["severity"], 0) >= minimum_rank
+    ]
 
 
 def extract_release_marker(note: str) -> str:

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -26,5 +26,18 @@ def test_handoff_rows_keep_input_order() -> None:
     assert filter_handoff_rows(rows) == rows
 
 
+def test_handoff_rows_filter_by_minimum_severity_in_input_order() -> None:
+    rows = [
+        {"owner": "platform", "severity": "medium", "summary": "Queue delay"},
+        {"owner": "support", "severity": "low", "summary": "Copy cleanup"},
+        {"owner": "release", "severity": "critical", "summary": "Escalation"},
+        {"owner": "docs", "severity": "unknown", "summary": "Draft note"},
+    ]
+
+    assert filter_handoff_rows(rows, minimum_severity="high") == [
+        {"owner": "release", "severity": "critical", "summary": "Escalation"},
+    ]
+
+
 def test_release_marker_trims_surrounding_whitespace() -> None:
     assert extract_release_marker("  20260530-rc2  ") == "20260530-rc2"

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.intake_service import (
     extract_release_marker,
     filter_handoff_rows,
@@ -37,6 +39,15 @@ def test_handoff_rows_filter_by_minimum_severity_in_input_order() -> None:
     assert filter_handoff_rows(rows, minimum_severity="high") == [
         {"owner": "release", "severity": "critical", "summary": "Escalation"},
     ]
+
+
+def test_handoff_rows_reject_unknown_minimum_severity() -> None:
+    rows = [
+        {"owner": "platform", "severity": "medium", "summary": "Queue delay"},
+    ]
+
+    with pytest.raises(ValueError, match="unknown minimum severity"):
+        filter_handoff_rows(rows, minimum_severity="urgent")
 
 
 def test_release_marker_trims_surrounding_whitespace() -> None:


### PR DESCRIPTION
## Summary

Implements [EXP-185](https://linear.app/expertmicro1fernandomano/issue/EXP-185/add-minimum-severity-filter-for-handoff-rows).

- Add optional `minimum_severity` filtering for handoff rows.
- Preserve no-threshold behavior and input ordering.
- Omit rows with unknown severities when filtering against a valid threshold.
- Raise `ValueError` when the supplied threshold itself is unknown.

## Validation

- `python3 -c "from src.intake_service import filter_handoff_rows; rows=[{'owner':'platform','severity':'medium','summary':'Queue delay'},{'owner':'support','severity':'low','summary':'Copy cleanup'},{'owner':'release','severity':'critical','summary':'Escalation'},{'owner':'docs','severity':'unknown','summary':'Draft note'}]; assert filter_handoff_rows(rows)==rows; assert filter_handoff_rows(rows, minimum_severity='high') == [rows[2]]; raised=[]; exec(\"try:\\n    filter_handoff_rows(rows, minimum_severity='urgent')\\nexcept ValueError:\\n    raised.append(True)\"); assert raised"`
- GitHub Actions CI passed on final head `6d2b4128758a1080d697147c8f8ccf1160ab6c07`.