### PR TITLE
Accept prefixed release markers

### DIFF
--- a/src/intake_service.py
+++ b/src/intake_service.py
@@ -47,4 +47,10 @@ def filter_handoff_rows(
 
 def extract_release_marker(note: str) -> str:
     """Normalize surrounding whitespace for a release marker."""
-    return note.strip()
+    marker = note.strip()
+    prefix = "release:"
+    if marker.lower().startswith(prefix):
+        marker = marker[len(prefix) :].strip()
+        if not marker:
+            raise ValueError("release marker prefix requires a marker value")
+    return marker

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -52,3 +52,12 @@ def test_handoff_rows_reject_unknown_minimum_severity() -> None:
 
 def test_release_marker_trims_surrounding_whitespace() -> None:
     assert extract_release_marker("  20260530-rc2  ") == "20260530-rc2"
+
+
+def test_release_marker_accepts_prefixed_support_note() -> None:
+    assert extract_release_marker("  ReLeAsE: 20260530-rc2  ") == "20260530-rc2"
+
+
+def test_release_marker_rejects_empty_prefixed_note() -> None:
+    with pytest.raises(ValueError, match="marker value"):
+        extract_release_marker(" release:   ")


### PR DESCRIPTION
## Summary

Implements [EXP-186](https://linear.app/expertmicro1fernandomano/issue/EXP-186/accept-prefixed-release-markers-from-support-notes).

- Preserve plain release marker trimming behavior.
- Accept a leading `release:` prefix case-insensitively after trimming.
- Reject prefix-only notes with no marker value.

## Validation

- `python3 -c "from src.intake_service import extract_release_marker; assert extract_release_marker('  20260530-rc2  ') == '20260530-rc2'; assert extract_release_marker('  ReLeAsE: 20260530-rc2  ') == '20260530-rc2'; raised=[]; exec(\"try:\\n    extract_release_marker(' release:   ')\\nexcept ValueError:\\n    raised.append(True)\"); assert raised"`
- Full local `python3 -m pytest` was not available because pytest is not installed in this local clone; GitHub Actions should run the suite.