### PR TITLE
Document retry override inheritance for intake handoffs

### DIFF
--- a/docs/intake-service.md
+++ b/docs/intake-service.md
@@ -3,6 +3,7 @@
 The intake helpers keep support handoff parsing separate from release coordination code.
 
 - Queue retry settings may be inherited from workspace configuration.
+- An explicit retry budget of `0` disables retries and must not be treated as inheritance.
 - Handoff rows remain in the order copied from support notes.
 - Release markers are normalized before they are included in status updates.
 


### PR DESCRIPTION
Clarifies how inherited retry settings interact with an explicit zero override in intake handoffs.

Validation:
- Reviewed the updated note in context.
- Confirmed this is documentation-only.
- No runtime behavior changed.