### PR TITLE
Preserve zero retry budget after workspace policy reload

### DIFF
--- a/src/workspace_policy.py
+++ b/src/workspace_policy.py
@@ -1,0 +1,13 @@
+"""Workspace-policy reload helpers for queue handoffs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def retry_budget_from_record(record: Mapping[str, object], default: int) -> int:
+    """Restore an explicit retry override from a persisted workspace record."""
+    requested = record.get("retry_budget")
+    if requested is None:
+        return default
+    return int(requested)


### PR DESCRIPTION
Restores an explicit retry budget of `0` when queue settings are loaded from a persisted workspace-policy record.

Related: #196

Validation:
- Reloaded a saved policy with `retry_budget: 0` and confirmed the queue receives `0`.
- Reloaded a policy with the field omitted and confirmed workspace-default inheritance still applies.
- Positive retry overrides remain unchanged.

Notes:
- The direct intake helper already has coverage for ordinary requests.
- I did not add a focused regression for the persisted reload boundary in this change.