### PR TITLE
Reject empty prefixed release marker values

### DIFF
--- a/src/release_marker_preview.py
+++ b/src/release_marker_preview.py
@@ -1,0 +1,17 @@
+"""Release-marker normalization for status previews."""
+
+from __future__ import annotations
+
+import re
+
+
+_RELEASE_PREFIX_RE = re.compile(r"^release:\\s*", re.IGNORECASE)
+
+
+def parse_release_marker_preview(note: str) -> str:
+    """Return a plain marker after removing an optional support-note prefix."""
+    marker = note.strip()
+    marker = _RELEASE_PREFIX_RE.sub("", marker, count=1).strip()
+    if not marker:
+        raise ValueError("release marker must include a value")
+    return marker

--- a/tests/test_release_marker_preview.py
+++ b/tests/test_release_marker_preview.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.release_marker_preview import parse_release_marker_preview
+
+
+def test_release_marker_preview_keeps_plain_marker() -> None:
+    assert parse_release_marker_preview("  20260603-rc1  ") == "20260603-rc1"
+
+
+def test_release_marker_preview_accepts_support_prefix() -> None:
+    assert parse_release_marker_preview(" ReLeAsE: 20260603-rc1 ") == "20260603-rc1"
+
+
+def test_release_marker_preview_rejects_empty_support_prefix() -> None:
+    with pytest.raises(ValueError, match="must include a value"):
+        parse_release_marker_preview(" release:   ")


### PR DESCRIPTION
Rejects copied support-note prefixes when no release marker remains after normalization.

Related: #197

Test coverage:
- Plain release markers remain unchanged.
- Case-insensitive `release:` prefixes are accepted.
- Empty values after prefix removal raise `ValueError`.