### PR TITLE
Skip blank owners while assembling handoff digests

### DIFF
--- a/src/handoff_digest.py
+++ b/src/handoff_digest.py
@@ -1,0 +1,12 @@
+"""Assemble the owner rows shown in release handoff digests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.intake_service import HandoffRow
+
+
+def assemble_handoff_digest(rows: Iterable[HandoffRow]) -> list[HandoffRow]:
+    """Drop copied rows whose owner field is blank before rendering sections."""
+    return [row for row in rows if row["owner"].strip()]


### PR DESCRIPTION
Drops whitespace-only owner rows before release handoff digest sections are rendered.

Related: #194

Validation:
- Pasted a handoff block with two named owners and one blank owner row.
- Confirmed the named sections remain in input order.
- Confirmed the blank section is excluded from the preview.

Notes:
- I spot-checked the assembled preview locally.
- I did not add a direct wrapper-path regression in this PR.