### PR TITLE
Update release escalation mailbox in checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -8,3 +8,5 @@
 - Verify migration confidence and rollback notes.
 - Confirm documentation links in PRs and Linear issues.
 - Tag unresolved risks before release cutoff.
+
+- Route unresolved cutover questions through `release-ops@company.example` until the handoff owner confirms the escalation alias.


### PR DESCRIPTION
Adds the release-operations alias to the cutover checklist so unresolved handoff questions have an explicit routing path.

Validation:
- Reviewed the checklist wording in context.
- Confirmed this is a documentation-only change.

Open question:
- Support still needs to confirm whether the long-term alias remains `release-ops@company.example` or moves to the escalation mailbox used by the handoff rotation.