### PR TITLE
Record release escalation owner lookup

### DIFF
--- a/docs/release/escalation-owner-lookup-20260605b.md
+++ b/docs/release/escalation-owner-lookup-20260605b.md
@@ -1,0 +1,11 @@
+# Release Escalation Owner Lookup
+
+When a handoff escalation alias changes during release week, confirm the support owner before checklist wording is treated as final.
+
+Repository: TC1
+Date: 2026-06-05
+
+Checklist:
+- Capture the current support owner in the PR discussion.
+- Record whether the escalation alias or mailbox is the source of truth.
+- Keep the release note wording consistent with the recorded owner decision.


### PR DESCRIPTION
Adds a short release-operations note for confirming the support owner before escalation routing copy is treated as final.

Validation:
- Reviewed the wording in the release handoff context.
- Confirmed this is documentation-only.
- No runtime behavior changed.