### PR TITLE
Add handoff digest whitespace fixture

### DIFF
--- a/docs/release/handoff-digest-whitespace-20260605b.md
+++ b/docs/release/handoff-digest-whitespace-20260605b.md
@@ -1,0 +1,16 @@
+# Handoff Digest Whitespace Fixture
+
+Repository: TC1
+Date: 2026-06-05
+
+Copied support transcript:
+
+| owner | severity | note |
+| --- | --- | --- |
+| Ana | high | retry budget needs release acknowledgement |
+|   | medium | pasted spacer row from support export |
+| Priya | critical | escalation mailbox handoff pending |
+
+Expected reviewer check:
+- Named owners should remain in their original order.
+- A blank owner row should not create a separate owner section.


### PR DESCRIPTION
Adds a pasted-transcript example for release handoff digests where a whitespace-only owner row appears between named owners.

Validation:
- Rendered the sample manually in the release preview.
- Confirmed the named owner rows remain readable.
- No production code changed.