### PR TITLE
Refresh release marker copy examples

### DIFF
--- a/docs/release/marker-copy-examples-20260605b.md
+++ b/docs/release/marker-copy-examples-20260605b.md
@@ -1,0 +1,16 @@
+# Release Marker Copy Examples
+
+Repository: TC1
+Date: 2026-06-05
+
+Accepted examples:
+
+- 20260605-rc2
+- release: 20260605-rc2
+- RELEASE: 20260605-rc2
+
+Rejected examples:
+
+- release:
+- RELEASE:
+- release:    


### PR DESCRIPTION
Refreshes examples for copied release marker text from support notes.

Validation:
- Reviewed examples for plain markers and prefixed markers.
- Confirmed this is documentation-only.
- No parser behavior changed.