### PR TITLE
Update nightly triage dry-run note

### DIFF
--- a/docs/release/nightly-triage-dry-run-20260605b.md
+++ b/docs/release/nightly-triage-dry-run-20260605b.md
@@ -1,0 +1,11 @@
+# Nightly Triage Dry Run
+
+Repository: TC1
+Date: 2026-06-05
+
+During release week, run the nightly triage dry run before posting status:
+
+1. Collect open release-path PRs.
+2. Check whether review follow-up is recorded in the appropriate project board.
+3. Separate shared CI baseline failures from branch-specific review blockers.
+4. Post only the unresolved release-facing items to the handoff channel.


### PR DESCRIPTION
Clarifies the nightly triage dry-run note used during release week.

Validation:
- Reviewed the note in the release checklist context.
- Confirmed this is documentation-only.
- No runtime behavior changed.