### PR TITLE
EXP-203: Guard release marker version against the reserved '-' delimiter

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -90,6 +90,10 @@ def summarize_signals_for_handoff(
 
 
 def build_release_marker(version: str, channel: str) -> str:
+    if "-" in version:
+        raise ValueError(
+            "release marker version must not contain '-' (reserved field delimiter)"
+        )
     timestamp = datetime.now(timezone.utc).strftime(RELEASE_MARKER_TIMESTAMP_FORMAT)
     normalized_channel = OWNER_SLUG_RE.sub("-", channel.strip().lower()).strip("-") or "internal"
     return f"{version}-{normalized_channel}-{timestamp}"

--- a/tests/test_release_marker_version_guard.py
+++ b/tests/test_release_marker_version_guard.py
@@ -1,0 +1,15 @@
+import pytest
+
+from src.tc1_service import build_release_marker, parse_release_marker
+
+
+def test_build_release_marker_rejects_hyphenated_version():
+    with pytest.raises(ValueError, match="reserved field delimiter"):
+        build_release_marker("1.4.0-rc1", "prod")
+
+
+def test_build_release_marker_allows_dotted_version_round_trip():
+    marker = build_release_marker("2026.06.09", "Prod Ops")
+    parsed = parse_release_marker(marker)
+    assert parsed.version == "2026.06.09"
+    assert parsed.channel == "prod-ops"


### PR DESCRIPTION
Fixes round-trip corruption in tc1_service release markers when the version contains the reserved '-' delimiter (e.g. a release candidate like 1.4.0-rc1).

build_release_marker now raises a clear ValueError when the version contains '-', instead of emitting a marker that parse_release_marker mis-splits into the wrong version/channel. Adds regression tests: hyphenated version rejected; dotted versions (e.g. 2026.06.09) still build and round-trip.

Linear: EXP-203 - https://linear.app/expertmicro1fernandomano/issue/EXP-203