### PR TITLE
EXP-204: add minimum severity filter for handoff summaries

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -57,6 +57,24 @@ def highest_severity(signals: Iterable[OperationSignal]) -> str:
     return severity
 
 
+def filter_signals_by_severity(
+    signals: Iterable[OperationSignal],
+    *,
+    min_severity: str | None = None,
+) -> list[OperationSignal]:
+    signal_list = list(signals)
+    if min_severity is None:
+        return signal_list
+    if min_severity not in SEVERITY_RANK:
+        raise ValueError(f"unknown minimum severity: {min_severity}")
+    minimum_rank = SEVERITY_RANK[min_severity]
+    return [
+        signal
+        for signal in signal_list
+        if SEVERITY_RANK.get(signal.severity, 0) >= minimum_rank
+    ]
+
+
 def group_signals_by_owner(
     signals: Iterable[OperationSignal],
     *,
@@ -78,8 +96,9 @@ def summarize_signals_for_handoff(
     signals: Iterable[OperationSignal],
     *,
     fallback_owner: str | None = None,
+    min_severity: str | None = None,
 ) -> HandoffSummary:
-    signal_list = list(signals)
+    signal_list = filter_signals_by_severity(signals, min_severity=min_severity)
     grouped = group_signals_by_owner(signal_list, fallback_owner=fallback_owner)
 
     return HandoffSummary(

--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -65,9 +65,10 @@ def filter_signals_by_severity(
     signal_list = list(signals)
     if min_severity is None:
         return signal_list
-    if min_severity not in SEVERITY_RANK:
+    threshold = min_severity.strip().lower()
+    if threshold not in SEVERITY_RANK:
         raise ValueError(f"unknown minimum severity: {min_severity}")
-    minimum_rank = SEVERITY_RANK[min_severity]
+    minimum_rank = SEVERITY_RANK[threshold]
     return [
         signal
         for signal in signal_list

--- a/tests/test_handoff_severity_filter.py
+++ b/tests/test_handoff_severity_filter.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.tc1_service import (
+    OperationSignal,
+    filter_signals_by_severity,
+    summarize_signals_for_handoff,
+)
+
+
+def _signal(name, severity, owner="ops"):
+    return OperationSignal(name, severity, owner, datetime.now(timezone.utc))
+
+
+def test_filter_preserves_order_and_threshold():
+    signals = [
+        _signal("queue-delay", "medium"),
+        _signal("copy-cleanup", "low"),
+        _signal("escalation", "critical"),
+        _signal("draft-note", "unknown"),
+    ]
+    filtered = filter_signals_by_severity(signals, min_severity="high")
+    assert [s.name for s in filtered] == ["escalation"]
+
+
+def test_filter_returns_all_without_threshold():
+    signals = [_signal("a", "low"), _signal("b", "high")]
+    assert filter_signals_by_severity(signals) == signals
+
+
+def test_filter_rejects_unknown_threshold():
+    with pytest.raises(ValueError, match="unknown minimum severity"):
+        filter_signals_by_severity([_signal("a", "low")], min_severity="urgent")
+
+
+def test_summarize_applies_min_severity():
+    signals = [
+        _signal("queue-delay", "medium", "platform"),
+        _signal("escalation", "critical", "release"),
+    ]
+    summary = summarize_signals_for_handoff(signals, min_severity="high")
+    assert summary.signal_count == 1
+    assert summary.highest_severity == "critical"
+    assert summary.owners == ("release",)

--- a/tests/test_handoff_severity_filter.py
+++ b/tests/test_handoff_severity_filter.py
@@ -43,3 +43,9 @@ def test_summarize_applies_min_severity():
     assert summary.signal_count == 1
     assert summary.highest_severity == "critical"
     assert summary.owners == ("release",)
+
+
+def test_filter_accepts_mixed_case_threshold():
+    signals = [_signal("a", "low"), _signal("b", "critical")]
+    filtered = filter_signals_by_severity(signals, min_severity="HIGH")
+    assert [s.name for s in filtered] == ["b"]


### PR DESCRIPTION
Adds an order-preserving minimum-severity filter to tc1_service handoff summarization, mirroring intake_service.filter_handoff_rows.

- New filter_signals_by_severity(signals, *, min_severity=None): returns signals at or above the threshold, preserving input order; raises ValueError on an unknown threshold.
- - summarize_signals_for_handoff gains an optional min_severity (default None keeps current behavior).
Includes tests for order/threshold filtering, unknown-threshold rejection, and summarize honoring min_severity.

Linear: EXP-204 - https://linear.app/expertmicro1fernandomano/issue/EXP-204