### PR TITLE
EXP-205: Accept prefixed release markers in parse_release_marker

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -96,6 +96,12 @@ def build_release_marker(version: str, channel: str) -> str:
 
 
 def parse_release_marker(marker: str) -> ReleaseMarker:
+    marker = marker.strip()
+    release_prefix = "release:"
+    if marker.lower().startswith(release_prefix):
+        marker = marker[len(release_prefix):].strip()
+        if not marker:
+            raise ValueError("release marker prefix requires a marker value")
     try:
         prefix, timestamp = marker.rsplit("-", maxsplit=1)
         version, channel = prefix.split("-", maxsplit=1)

--- a/tests/test_release_marker_prefix.py
+++ b/tests/test_release_marker_prefix.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.tc1_service import parse_release_marker
+
+
+def test_parse_accepts_release_prefix():
+    parsed = parse_release_marker("release: 2026.05.25-internal-202605251630")
+    assert parsed.version == "2026.05.25"
+    assert parsed.channel == "internal"
+
+
+def test_parse_accepts_mixed_case_prefix():
+    parsed = parse_release_marker("  ReLeAsE:2026.05.25-internal-202605251630 ")
+    assert parsed.version == "2026.05.25"
+
+
+def test_parse_rejects_empty_prefixed_value():
+    with pytest.raises(ValueError, match="marker value"):
+        parse_release_marker("release:   ")


### PR DESCRIPTION
Accepts an optional, case-insensitive 'release:' prefix (with surrounding whitespace) in tc1_service.parse_release_marker, mirroring intake_service.extract_release_marker.

Markers pasted from support notes like 'release: 2026.05.25-internal-202605251630' now parse correctly; if only the prefix is supplied, a clear ValueError is raised. Markers without the prefix are unaffected.

Includes tests for prefixed parsing, mixed-case prefix, and empty prefixed value rejection.

Linear: EXP-205 - https://linear.app/expertmicro1fernandomano/issue/EXP-205