### PR TITLE
Document audit export retention exception

### DIFF
--- a/docs/review-followup/audit-export-retention-exception.md
+++ b/docs/review-followup/audit-export-retention-exception.md
@@ -7,3 +7,5 @@ A 90-day exception may be used after a named policy owner approves the request a
 Open decision:
 - Security and Compliance still need to record which function owns final approval.
 - The checklist should not present the exception as final until that owner is named.
+
+Last reviewed: 2026-06-10.

--- a/docs/review-followup/audit-export-retention-exception.md
+++ b/docs/review-followup/audit-export-retention-exception.md
@@ -1,0 +1,9 @@
+# Audit Export Retention Exception
+
+Customer-requested audit exports use a 30-day retention period by default.
+
+A 90-day exception may be used after a named policy owner approves the request and the approval is recorded with the release checklist.
+
+Open decision:
+- Security and Compliance still need to record which function owns final approval.
+- The checklist should not present the exception as final until that owner is named.


### PR DESCRIPTION
Documents the retention exception used for customer-requested audit exports.

Validation:
- Reviewed the wording against the current release checklist.
- Confirmed this is documentation-only.
- CI is expected to remain green.

Open decision:
- Security and Compliance have not yet recorded which function owns final approval for the 90-day exception.