### PR TITLE
Add copied incident owner row example

### DIFF
--- a/docs/review-followup/copied-incident-owner-rows.md
+++ b/docs/review-followup/copied-incident-owner-rows.md
@@ -1,0 +1,13 @@
+# Copied Incident Owner Row Example
+
+Copied transcript:
+
+| owner | severity | note |
+| --- | --- | --- |
+| Ana | high | retry budget needs release acknowledgement |
+|   | medium | spacer row preserved by the support export |
+| Priya | critical | escalation mailbox handoff pending |
+
+Expected assembled digest:
+- Keep Ana before Priya.
+- Do not create a separate section for the whitespace-only owner row.

--- a/docs/review-followup/copied-incident-owner-rows.md
+++ b/docs/review-followup/copied-incident-owner-rows.md
@@ -11,3 +11,5 @@ Copied transcript:
 Expected assembled digest:
 - Keep Ana before Priya.
 - Do not create a separate section for the whitespace-only owner row.
+
+Last reviewed: 2026-06-10.


### PR DESCRIPTION
Adds a copied incident transcript example with a whitespace-only owner row between named owners.

Validation:
- Rendered the sample manually in the release preview.
- Confirmed the named owners remain readable and in order.
- A direct assembled-digest regression is not included in this PR.
- CI is expected to remain green.