### PR TITLE
Document retry schedule midnight rollover

### DIFF
--- a/docs/review-followup/retry-schedule-midnight-rollover.md
+++ b/docs/review-followup/retry-schedule-midnight-rollover.md
@@ -7,3 +7,5 @@ Release rehearsal examples:
 - An omitted retry override continues to inherit the workspace default.
 
 The release checklist should cite these examples only after the loader and scheduler boundary is covered directly.
+
+Last reviewed: 2026-06-10.

--- a/docs/review-followup/retry-schedule-midnight-rollover.md
+++ b/docs/review-followup/retry-schedule-midnight-rollover.md
@@ -1,0 +1,9 @@
+# Retry Schedule Midnight Rollover
+
+Release rehearsal examples:
+
+- A retry scheduled at 23:59:30 UTC with a 45-second delay runs at 00:00:15 UTC on the next date.
+- An explicit retry budget of 0 still means no retry is scheduled.
+- An omitted retry override continues to inherit the workspace default.
+
+The release checklist should cite these examples only after the loader and scheduler boundary is covered directly.


### PR DESCRIPTION
Documents retry scheduling examples across the UTC date boundary.

Validation:
- Reviewed the examples against the release rehearsal notes.
- Confirmed this is documentation-only.
- A deterministic loader/scheduler boundary regression is not included in this PR.
- CI is expected to remain green.