### PR TITLE
Clarify nightly triage dry-run ordering

### DIFF
--- a/docs/review-followup/nightly-triage-ordering.md
+++ b/docs/review-followup/nightly-triage-ordering.md
@@ -1,0 +1,9 @@
+# Nightly Triage Dry-Run Ordering
+
+During release week:
+
+1. Collect open release-path pull requests.
+2. Review current-head discussion and review history.
+3. Check CI before deciding whether follow-up remains.
+4. Update the project board only for unresolved work.
+5. Post the release-facing summary after tracking is reconciled.

--- a/docs/review-followup/nightly-triage-ordering.md
+++ b/docs/review-followup/nightly-triage-ordering.md
@@ -4,6 +4,7 @@ During release week:
 
 1. Collect open release-path pull requests.
 2. Review current-head discussion and review history.
-3. Check CI before deciding whether follow-up remains.
-4. Update the project board only for unresolved work.
-5. Post the release-facing summary after tracking is reconciled.
+3. Check CI and compare the PR head with the latest main-branch run.
+4. Separate shared baseline failures from failures introduced by the PR head.
+5. Update the project board only for unresolved work.
+6. Post the release-facing summary after tracking is reconciled.

--- a/docs/review-followup/nightly-triage-ordering.md
+++ b/docs/review-followup/nightly-triage-ordering.md
@@ -8,3 +8,5 @@ During release week:
 4. Separate shared baseline failures from failures introduced by the PR head.
 5. Update the project board only for unresolved work.
 6. Post the release-facing summary after tracking is reconciled.
+
+Last reviewed: 2026-06-10.


### PR DESCRIPTION
Clarifies the nightly triage dry-run order used during release week.

Validation:
- Reviewed the sequence against the current handoff checklist.
- Confirmed this is documentation-only.
- CI is expected to remain green.