### PR TITLE
Normalize blank owners before digest grouping

### DIFF
--- a/src/handoff_owner_normalization.py
+++ b/src/handoff_owner_normalization.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+def normalize_owner(value: object) -> str | None:
+    owner = str(value or "").strip()
+    return owner or None
+
+
+def named_owners(rows: Iterable[Mapping[str, object]]) -> list[str]:
+    owners: list[str] = []
+    for row in rows:
+        owner = normalize_owner(row.get("owner"))
+        if owner is not None:
+            owners.append(owner)
+    return owners


### PR DESCRIPTION
Normalizes blank and whitespace-only owner values before release-digest grouping.

Validation:
- Named owners remain in input order.
- Blank owners are excluded before grouping.
- CI is expected to remain green.

Follow-up:
- A direct assembled-digest regression is not included in this PR.