### PR TITLE
Drop whitespace-only owners from copied transcripts

### DIFF
--- a/src/copied_owner_cleanup.py
+++ b/src/copied_owner_cleanup.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+def remove_blank_owner_rows(rows: Iterable[Mapping[str, object]]) -> list[Mapping[str, object]]:
+    return [row for row in rows if str(row.get("owner") or "").strip()]


### PR DESCRIPTION
Drops copied transcript rows whose owner value contains only whitespace.

Validation:
- Preserves named-row order.
- Leaves non-owner fields unchanged.
- CI is expected to remain green.

This is a draft while overlap with the owner-normalization branch is reviewed.