### PR TITLE
Make audit completion notifications idempotent

### DIFF
--- a/src/export_notification_idempotency.py
+++ b/src/export_notification_idempotency.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+class NotificationLedger:
+    def __init__(self) -> None:
+        self._sent: set[str] = set()
+
+    def claim(self, export_job_id: str) -> bool:
+        if export_job_id in self._sent:
+            return False
+        self._sent.add(export_job_id)
+        return True


### PR DESCRIPTION
Adds an export-job ledger so callback retries do not send a second completion notification.

Validation:
- A repeated export job ID is rejected after the first send.
- Different export jobs remain independent.
- CI is expected to remain green.

Follow-up:
- The reconnect/callback-retry path is not covered directly.