### PR TITLE
Persist minimum severity in saved handoff filters

### DIFF
--- a/src/handoff_filter_state.py
+++ b/src/handoff_filter_state.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+_FILTER_FIELDS = ("owner", "window", "minimum_severity")
+
+
+def save_filter(values: Mapping[str, object]) -> dict[str, object]:
+    return {key: values[key] for key in _FILTER_FIELDS if key in values}
+
+
+def restore_filter(values: Mapping[str, object]) -> dict[str, object]:
+    restored = save_filter(values)
+    restored.setdefault("minimum_severity", "low")
+    return restored


### PR DESCRIPTION
Persists `minimum_severity` alongside owner and time-window fields in saved handoff filters.

Validation:
- Save and restore preserve the configured fields.
- Unknown fields are ignored.
- CI is expected to remain green.

Follow-up:
- Scheduled handoff reload coverage is not included.