### PR TITLE
Redact signed query parameters before delivery logging

### DIFF
--- a/src/delivery_log_redaction.py
+++ b/src/delivery_log_redaction.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+
+def redact_download_url(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", parts.fragment))


### PR DESCRIPTION
Strips query parameters from signed audit-export URLs before delivery diagnostics are persisted.

Validation:
- Keeps the scheme, host, path, and fragment.
- Removes the complete query string.
- CI is expected to remain green.

Follow-up:
- The upstream-`502` retry logging path does not have a direct regression in this PR.