### PR TITLE
Normalize escalation deadlines to UTC

### DIFF
--- a/src/escalation_deadlines.py
+++ b/src/escalation_deadlines.py
@@ -1,0 +1,8 @@
+from datetime import datetime, timezone
+
+
+def normalize_escalation_deadline(value):
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("deadline must include a timezone")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/tests/test_escalation_deadlines.py
+++ b/tests/test_escalation_deadlines.py
@@ -1,0 +1,5 @@
+from src.escalation_deadlines import normalize_escalation_deadline
+
+
+def test_normalizes_offset_deadline_to_utc():
+    assert normalize_escalation_deadline("2026-06-17T09:00:00-04:00") == "2026-06-17T13:00:00Z"


### PR DESCRIPTION
Normalize release escalation deadlines at ingestion so deploy coordination, reminders, and customer-facing status notes compare the same instant.

Validation: offset-to-UTC unit coverage. This replaces local-time normalization in the release path.