### PR TITLE
Increase export worker timeout for large workspaces

### DIFF
--- a/config/export_worker_timeout.yml
+++ b/config/export_worker_timeout.yml
@@ -1,0 +1,4 @@
+export_worker:
+  timeout_minutes: 25
+  applies_to: large_workspace_exports
+  retry_budget: 1


### PR DESCRIPTION
Increase the release export worker timeout from 15 to 25 minutes for large workspaces. The change is intentionally limited to the export worker queue.

QA follow-up: complete the 500k-row staging soak before calling the release risk closed.