### PR TITLE
Require artifact signature before promotion

### DIFF
--- a/src/artifact_signature_gate.py
+++ b/src/artifact_signature_gate.py
@@ -1,0 +1,2 @@
+def can_promote_artifact(metadata):
+    return bool(metadata.get("signature_verified"))

--- a/tests/test_artifact_signature_gate.py
+++ b/tests/test_artifact_signature_gate.py
@@ -1,0 +1,9 @@
+from src.artifact_signature_gate import can_promote_artifact
+
+
+def test_rejects_unsigned_artifact():
+    assert can_promote_artifact({"signature_verified": False}) is False
+
+
+def test_allows_verified_artifact():
+    assert can_promote_artifact({"signature_verified": True}) is True


### PR DESCRIPTION
Reject unsigned release artifacts before they enter the promotion queue. Signed artifacts retain the existing promotion behavior.

Validation: targeted gate coverage for signed and unsigned artifacts.