### PR TITLE
Link deployment summaries to the release checklist

### DIFF
--- a/docs/release/deployment-summary-links.md
+++ b/docs/release/deployment-summary-links.md
@@ -1,0 +1,3 @@
+# Deployment summary links
+
+Every release deployment summary must include a link to `docs/release-checklist.md` and identify the release candidate being assessed.


### PR DESCRIPTION
Add the canonical release checklist path to deployment summaries so release owners can move from the status note to the current validation steps without searching.