### PR TITLE
Deduplicate billing export rows across retry attempts

### DIFF
--- a/src/billing_manifest_rows.py
+++ b/src/billing_manifest_rows.py
@@ -1,0 +1,10 @@
+def coalesce_retry_rows(rows):
+    result = []
+    seen = set()
+    for row in sorted(rows, key=lambda item: item.get("attempt", 0), reverse=True):
+        key = (row["invoice_id"], row.get("attempt", 0))
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(row)
+    return list(reversed(result))

--- a/tests/test_billing_manifest_rows.py
+++ b/tests/test_billing_manifest_rows.py
@@ -1,0 +1,10 @@
+from src.billing_manifest_rows import coalesce_retry_rows
+
+
+def test_keeps_only_newest_retry_row_for_invoice():
+    rows = [
+        {"invoice_id": "inv-2048", "attempt": 1, "amount": 7200},
+        {"invoice_id": "inv-2048", "attempt": 2, "amount": 7200},
+    ]
+
+    assert coalesce_retry_rows(rows) == [rows[1]]


### PR DESCRIPTION
Billing export retries can append the same invoice more than once when a delivery attempt is reconstructed. Coalesce retry rows by invoice identity while preserving the newest attempt.

Validation: targeted regression for two attempts of the same invoice.