### PR TITLE
Record the regional failover release approver

### DIFF
--- a/docs/release/regional-failover-approval.md
+++ b/docs/release/regional-failover-approval.md
@@ -1,0 +1,8 @@
+# Regional failover approval
+
+Regional failover promotions require one recorded final approver before the release status can move to ready.
+
+- Release coordinator: Release Operations
+- Technical verifier: Platform Reliability
+- Final approval owner: TBD (Release Operations or Platform Reliability)
+- Decision deadline: 2026-06-17 13:00 UTC


### PR DESCRIPTION
Document the approval path for regional failover releases before the June 17 release checkpoint. The deployment mechanics are unchanged; this PR records who has final authority to approve a failover promotion.