### PR TITLE
Add a notification replay canary assertion

### DIFF
--- a/src/notification_replay_canary.py
+++ b/src/notification_replay_canary.py
@@ -1,0 +1,5 @@
+def replay_canary_is_healthy(samples):
+    return all(
+        not sample.get("duplicate", False) and sample.get("latency_ms", 0) < 2000
+        for sample in samples
+    )

--- a/tests/test_notification_replay_canary.py
+++ b/tests/test_notification_replay_canary.py
@@ -1,0 +1,13 @@
+from src.notification_replay_canary import replay_canary_is_healthy
+
+
+def test_accepts_clean_replay_samples():
+    samples = [
+        {"duplicate": False, "latency_ms": 420},
+        {"duplicate": False, "latency_ms": 610},
+    ]
+    assert replay_canary_is_healthy(samples) is True
+
+
+def test_rejects_duplicate_delivery():
+    assert replay_canary_is_healthy([{"duplicate": True, "latency_ms": 300}]) is False


### PR DESCRIPTION
Add a small release canary check that treats duplicate delivery or latency above two seconds as unhealthy. QA will use the same rule for the replay sweep before the next status update.