### PR TITLE
Normalize release deadline timestamps in the status adapter

### DIFF
--- a/src/release_deadline_adapter.py
+++ b/src/release_deadline_adapter.py
@@ -1,0 +1,5 @@
+from src.escalation_deadlines import normalize_escalation_deadline
+
+
+def release_status_deadline(value):
+    return normalize_escalation_deadline(value)

--- a/tests/test_release_deadline_adapter.py
+++ b/tests/test_release_deadline_adapter.py
@@ -1,0 +1,5 @@
+from src.release_deadline_adapter import release_status_deadline
+
+
+def test_status_adapter_uses_utc_deadline():
+    assert release_status_deadline("2026-06-17T09:00:00-04:00") == "2026-06-17T13:00:00Z"


### PR DESCRIPTION
Normalize release deadline values before they enter the status adapter. This branch was started while the shared escalation-deadline normalization change was still under review.