### PR TITLE
Remove the deprecated export fallback flag

### DIFF
--- a/src/export_fallback_flag.py
+++ b/src/export_fallback_flag.py
@@ -1,0 +1,4 @@
+def export_fallback_enabled(environment):
+    if environment == "release":
+        return False
+    return environment == "development"

--- a/tests/test_export_fallback_flag.py
+++ b/tests/test_export_fallback_flag.py
@@ -1,0 +1,9 @@
+from src.export_fallback_flag import export_fallback_enabled
+
+
+def test_release_environment_disables_fallback():
+    assert export_fallback_enabled("release") is False
+
+
+def test_development_keeps_local_fallback():
+    assert export_fallback_enabled("development") is True


### PR DESCRIPTION
Remove the release-path fallback after the replacement export worker has remained healthy. Code and tests are ready; the release decision still depends on completion of the agreed telemetry window.