### PR TITLE
Cache customer export schema by workspace version

### DIFF
--- a/src/export_schema_cache.py
+++ b/src/export_schema_cache.py
@@ -1,0 +1,13 @@
+_schema_cache = {}
+
+
+def export_schema(workspace_id, workspace_version, fields):
+    if workspace_id in _schema_cache:
+        return _schema_cache[workspace_id]
+    schema = tuple(fields)
+    _schema_cache[workspace_id] = schema
+    return schema
+
+
+def clear_export_schema_cache():
+    _schema_cache.clear()

--- a/tests/test_export_schema_cache.py
+++ b/tests/test_export_schema_cache.py
@@ -1,0 +1,9 @@
+from src.export_schema_cache import clear_export_schema_cache, export_schema
+
+
+def test_reuses_schema_for_unchanged_workspace_version():
+    clear_export_schema_cache()
+    fields = ["invoice_id", "amount"]
+    first = export_schema("ws-204", 7, fields)
+    second = export_schema("ws-204", 7, list(fields))
+    assert second == first


### PR DESCRIPTION
Cache the resolved customer export schema during retry processing so repeated export attempts do not rebuild the same field map.

Validation: targeted coverage for repeated reads of an unchanged workspace version.

Release follow-up: verify that a workspace version change cannot reuse the previous schema entry.