### PR TITLE
Normalize release-region aliases at ingestion

### DIFF
--- a/src/release_region.py
+++ b/src/release_region.py
@@ -1,0 +1,11 @@
+REGION_ALIASES = {
+    "us-east": "us-east-1",
+    "use1": "us-east-1",
+    "eu-west": "eu-west-1",
+    "euw1": "eu-west-1",
+}
+
+
+def normalize_release_region(value):
+    key = value.strip().lower()
+    return REGION_ALIASES.get(key, key)

--- a/tests/test_release_region.py
+++ b/tests/test_release_region.py
@@ -1,0 +1,6 @@
+from src.release_region import normalize_release_region
+
+
+def test_normalizes_supported_aliases():
+    assert normalize_release_region(" USE1 ") == "us-east-1"
+    assert normalize_release_region("eu-west") == "eu-west-1"


### PR DESCRIPTION
Normalize supported release-region aliases before deployment plans are persisted so status updates and rollback routing use one canonical region key.

Validation: targeted alias coverage.