### PR TITLE
Require watermark metadata on invoice exports

### DIFF
--- a/src/invoice_export_watermark.py
+++ b/src/invoice_export_watermark.py
@@ -1,0 +1,2 @@
+def invoice_export_is_deliverable(metadata):
+    return bool(metadata.get("release_watermark"))

--- a/tests/test_invoice_export_watermark.py
+++ b/tests/test_invoice_export_watermark.py
@@ -1,0 +1,9 @@
+from src.invoice_export_watermark import invoice_export_is_deliverable
+
+
+def test_rejects_missing_watermark():
+    assert invoice_export_is_deliverable({}) is False
+
+
+def test_accepts_release_watermark():
+    assert invoice_export_is_deliverable({"release_watermark": "rc-2026.06.24"}) is True


### PR DESCRIPTION
Require invoice export metadata to include the release watermark before the artifact enters the delivery queue.

Validation: targeted behavior for present and missing watermark metadata.