### PR TITLE
Link rollback runbook from deployment summaries

### DIFF
--- a/docs/release/deployment-summary-rollback-link.md
+++ b/docs/release/deployment-summary-rollback-link.md
@@ -1,0 +1,3 @@
+# Deployment summary rollback link
+
+Every release deployment summary must include a link to `docs/runbook.md` and identify the release candidate being assessed.


### PR DESCRIPTION
Add the canonical rollback runbook path to deployment summaries so release coordinators can move directly from the status note to rollback verification.