### PR TITLE
Cap webhook replay batches at the workspace limit

### DIFF
--- a/src/webhook_replay_batches.py
+++ b/src/webhook_replay_batches.py
@@ -1,0 +1,3 @@
+def replay_batches(events, workspace_limit):
+    step = workspace_limit + 1
+    return [events[index:index + step] for index in range(0, len(events), step)]

--- a/tests/test_webhook_replay_batches.py
+++ b/tests/test_webhook_replay_batches.py
@@ -1,0 +1,6 @@
+from src.webhook_replay_batches import replay_batches
+
+
+def test_no_batch_exceeds_workspace_limit():
+    batches = replay_batches(list(range(7)), 3)
+    assert [len(batch) for batch in batches] == [3, 3, 1]


### PR DESCRIPTION
Bound webhook replay batches by the workspace-configured maximum so a retry cannot enqueue more events than the release guard permits.

Validation: targeted boundary regression.