### PR TITLE
Record the mobile export rollback approval owner

### DIFF
--- a/docs/release/mobile-export-rollback-owner.md
+++ b/docs/release/mobile-export-rollback-owner.md
@@ -1,0 +1,8 @@
+# Mobile export rollback approval
+
+Mobile export rollback requires one recorded final approver before release status can move to ready.
+
+- Release coordinator: Mobile Operations
+- Technical verifier: Export Platform
+- Final approval owner: TBD (Mobile Operations or Export Platform)
+- Decision deadline: 2026-06-24 13:00 UTC


### PR DESCRIPTION
Document the approval path for mobile export rollback before the RC-2026.06.24 checkpoint. Deployment mechanics are unchanged; this PR records final rollback authority.