### PR TITLE
Add a credit memo reconciliation canary

### DIFF
--- a/src/credit_memo_canary.py
+++ b/src/credit_memo_canary.py
@@ -1,0 +1,5 @@
+def reconciliation_canary_is_healthy(samples):
+    return all(
+        not sample.get("duplicate", False) and sample.get("latency_ms", 0) < 3000
+        for sample in samples
+    )

--- a/tests/test_credit_memo_canary.py
+++ b/tests/test_credit_memo_canary.py
@@ -1,0 +1,10 @@
+from src.credit_memo_canary import reconciliation_canary_is_healthy
+
+
+def test_accepts_clean_reconciliation_samples():
+    samples = [{"duplicate": False, "latency_ms": 720}, {"duplicate": False, "latency_ms": 910}]
+    assert reconciliation_canary_is_healthy(samples) is True
+
+
+def test_rejects_duplicate_output():
+    assert reconciliation_canary_is_healthy([{"duplicate": True, "latency_ms": 500}]) is False


### PR DESCRIPTION
Add a release canary rule for credit memo reconciliation. Duplicate output or processing latency above three seconds is unhealthy.