### PR TITLE
Normalize release-region aliases in deployment plans

### DIFF
--- a/src/deployment_plan_region.py
+++ b/src/deployment_plan_region.py
@@ -1,0 +1,5 @@
+from src.release_region import normalize_release_region
+
+
+def deployment_plan_region(value):
+    return normalize_release_region(value)

--- a/tests/test_deployment_plan_region.py
+++ b/tests/test_deployment_plan_region.py
@@ -1,0 +1,5 @@
+from src.deployment_plan_region import deployment_plan_region
+
+
+def test_deployment_plan_uses_canonical_region():
+    assert deployment_plan_region("USE1") == "us-east-1"


### PR DESCRIPTION
Normalize region values in the deployment-plan adapter. This draft began while the shared ingestion normalization was still under review.