### PR TITLE
Remove the legacy webhook signature fallback

### DIFF
--- a/src/webhook_signature_fallback.py
+++ b/src/webhook_signature_fallback.py
@@ -1,0 +1,4 @@
+def legacy_signature_fallback_enabled(environment):
+    if environment == "release":
+        return False
+    return environment == "development"

--- a/tests/test_webhook_signature_fallback.py
+++ b/tests/test_webhook_signature_fallback.py
@@ -1,0 +1,9 @@
+from src.webhook_signature_fallback import legacy_signature_fallback_enabled
+
+
+def test_release_disables_legacy_fallback():
+    assert legacy_signature_fallback_enabled("release") is False
+
+
+def test_development_keeps_local_fallback():
+    assert legacy_signature_fallback_enabled("development") is True


### PR DESCRIPTION
Remove the legacy webhook signature fallback after the replacement verifier remains healthy. Code and tests are ready; release approval depends on the full telemetry window.