### PR TITLE
Document invoice export watermark behavior

### DIFF
--- a/docs/release/invoice-export-watermark.md
+++ b/docs/release/invoice-export-watermark.md
@@ -1,0 +1,5 @@
+# Invoice export watermark
+
+Invoice export artifacts must include a release watermark before entering the delivery queue. Missing-watermark artifacts should be rebuilt from the approved release candidate.
+
+The gate is active for RC-2026.06.24.


### PR DESCRIPTION
Add operator-facing release wording for the invoice export watermark gate that is already merged. This changes documentation only.