### PR TITLE
Cover blank release marker defaults

### DIFF
--- a/src/release_notes.py
+++ b/src/release_notes.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OperationSignal:
+    owner: str
+    severity: str
+
+
+def build_release_marker(version: str, channel: str) -> str:
+    normalized_channel = channel.strip() or "internal"
+    return f"{version}-{normalized_channel}"

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -1,0 +1,6 @@
+from src.release_notes import build_release_marker
+
+
+def test_blank_release_marker_channel_uses_internal_default():
+    assert build_release_marker("2026.06.24", "") == "2026.06.24-internal"
+    assert build_release_marker("2026.06.24", "   ") == "2026.06.24-internal"


### PR DESCRIPTION
Adds direct regression coverage for blank or whitespace channel input so release markers keep the default internal path when no channel is supplied.

Test coverage:
- Added direct blank-channel assertions beside the shared release-note helper.
- Existing parser and timestamp behavior remains unchanged.