### PR TITLE
Sort handoff summary owners for stable notes

### DIFF
--- a/src/release_notes.py
+++ b/src/release_notes.py
@@ -34,7 +34,7 @@ def summarize_signals_for_handoff(
 ) -> HandoffSummary:
     rows = tuple(signals)
     owners = tuple(
-        dict.fromkeys(signal.owner.strip() or fallback_owner for signal in rows)
+        sorted({signal.owner.strip() or fallback_owner for signal in rows})
     )
     highest = max(
         (signal.severity for signal in rows),


### PR DESCRIPTION
Sorts owners in handoff summaries so release notes stay stable across batches copied from support handoffs.

Validation:
- Checked two sample handoff batches with the same owners in different arrival order.
- Existing grouping behavior is unchanged.