### PR TITLE
Cover direct handoff helper edges

### DIFF
--- a/src/release_notes.py
+++ b/src/release_notes.py
@@ -28,17 +28,28 @@ def build_release_marker(version: str, channel: str) -> str:
     return f"{version}-{normalized_channel}"
 
 
+def highest_severity(signals: Iterable[OperationSignal]) -> str:
+    return max(
+        (signal.severity for signal in signals),
+        key=lambda severity: SEVERITY_RANK[severity],
+        default="low",
+    )
+
+
+def group_signal_owners(
+    signals: Iterable[OperationSignal],
+    fallback_owner: str,
+) -> tuple[str, ...]:
+    return tuple(
+        sorted({signal.owner.strip() or fallback_owner for signal in signals})
+    )
+
+
 def summarize_signals_for_handoff(
     signals: Iterable[OperationSignal],
     fallback_owner: str = "engineering-ops",
 ) -> HandoffSummary:
     rows = tuple(signals)
-    owners = tuple(
-        sorted({signal.owner.strip() or fallback_owner for signal in rows})
-    )
-    highest = max(
-        (signal.severity for signal in rows),
-        key=lambda severity: SEVERITY_RANK[severity],
-        default="low",
-    )
+    owners = group_signal_owners(rows, fallback_owner)
+    highest = highest_severity(rows)
     return HandoffSummary(highest, owners, len(rows))

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -1,6 +1,29 @@
-from src.release_notes import build_release_marker
+from src.release_notes import (
+    OperationSignal,
+    build_release_marker,
+    group_signal_owners,
+    highest_severity,
+)
 
 
 def test_blank_release_marker_channel_uses_internal_default():
     assert build_release_marker("2026.06.24", "") == "2026.06.24-internal"
     assert build_release_marker("2026.06.24", "   ") == "2026.06.24-internal"
+
+
+def test_generator_backed_severity_uses_highest_signal():
+    signals = (
+        OperationSignal("platform", severity)
+        for severity in ("low", "critical", "medium")
+    )
+
+    assert highest_severity(signals) == "critical"
+
+
+def test_blank_owner_uses_configured_fallback():
+    signals = (OperationSignal(owner, "high") for owner in ("", "platform"))
+
+    assert group_signal_owners(signals, "engineering-ops") == (
+        "engineering-ops",
+        "platform",
+    )


### PR DESCRIPTION
Adds direct helper coverage for fallback grouping and generator-backed severity checks used by handoff paths.

Test coverage:
- Added a generator fallback-owner grouping case.
- Added a generator batch severity case.
- Existing marker normalization coverage stays intact.