### PR TITLE
Raise stale review threshold during cutover

### DIFF
--- a/config/cutover_review.yml
+++ b/config/cutover_review.yml
@@ -1,0 +1,4 @@
+review:
+  baseline_stale_after_days: 4
+  stale_after_days: 5
+  scope: cutover


### PR DESCRIPTION
Raises the stale review threshold from 4 to 5 during cutover week so same-head follow-up pushes do not fall into stale review too early.

Validation:
- Checked the current review queue after the threshold change.
- This is configuration-only.