### PR TITLE
Clarify cutover handoff checklist

### DIFF
--- a/docs/release/cutover-handoff-checklist.md
+++ b/docs/release/cutover-handoff-checklist.md
@@ -1,0 +1,6 @@
+# Cutover Handoff Checklist
+
+- Confirm the release-note owner before the cutoff.
+- Use the five-day cutover window when checking the stale review queue.
+- Keep the release note and review queue owner wording aligned.
+- Record any production-cycle threshold exception in release coordination.


### PR DESCRIPTION
Clarifies the cutover handoff checklist so release notes and review queue checks use the same owner and stale-window language.

No runtime behavior changes.

Validation:
- Reviewed the checklist wording against today's cutover handoff.
- Confirmed no service code or configuration changed.