### PR TITLE
Document maintenance-window approval roles

### DIFF
--- a/docs/maintenance-window-approval.md
+++ b/docs/maintenance-window-approval.md
@@ -1,0 +1,6 @@
+# Maintenance Window Approval
+
+Regional Reliability confirms the drain check before deployment begins.
+Release Operations coordinates the deployment timeline and customer updates.
+
+The final go/no-go owner for an overlapping maintenance window is still to be recorded.


### PR DESCRIPTION
Documents the operational roles used when a regional maintenance window overlaps a release deployment.

Validation:
- Reviewed the wording against the current release checklist.
- Documentation only; no runtime behavior changed.