### PR TITLE
Cache policy snapshots during export retries

### DIFF
--- a/src/policy_cache.py
+++ b/src/policy_cache.py
@@ -1,0 +1,17 @@
+from collections.abc import Callable
+
+
+class PolicySnapshotCache:
+    def __init__(self) -> None:
+        self._entries: dict[tuple[str, int], dict[str, object]] = {}
+
+    def get_or_load(
+        self,
+        workspace_id: str,
+        version: int,
+        loader: Callable[[], dict[str, object]],
+    ) -> dict[str, object]:
+        key = (workspace_id, version)
+        if key not in self._entries:
+            self._entries[key] = loader()
+        return self._entries[key]

--- a/tests/test_policy_cache.py
+++ b/tests/test_policy_cache.py
@@ -1,0 +1,32 @@
+import unittest
+
+from src.policy_cache import PolicySnapshotCache
+
+
+class PolicySnapshotCacheTests(unittest.TestCase):
+    def test_same_workspace_version_reuses_snapshot(self):
+        cache = PolicySnapshotCache()
+        loads = []
+
+        def load():
+            loads.append("load")
+            return {"retry_budget": 3}
+
+        first = cache.get_or_load("workspace-7", 12, load)
+        second = cache.get_or_load("workspace-7", 12, load)
+
+        self.assertIs(first, second)
+        self.assertEqual(loads, ["load"])
+
+    def test_new_workspace_version_loads_new_snapshot(self):
+        cache = PolicySnapshotCache()
+        versions = iter(({"retry_budget": 3}, {"retry_budget": 0}))
+
+        first = cache.get_or_load("workspace-7", 12, lambda: next(versions))
+        second = cache.get_or_load("workspace-7", 13, lambda: next(versions))
+
+        self.assertNotEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Caches resolved policy snapshots by workspace and version so repeated export retries reuse an unchanged policy while a newer version loads a fresh snapshot.

Validation:
- Unit coverage verifies same-version reuse and new-version reload.
- Retry-worker integration coverage is deferred.