### PR TITLE
Honor region-specific freeze windows in deployment planner

### DIFF
--- a/src/freeze_window.py
+++ b/src/freeze_window.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def is_in_freeze_window(
+    instant: datetime,
+    timezone_name: str,
+    start_hour: int,
+    end_hour: int,
+) -> bool:
+    local_hour = instant.astimezone(ZoneInfo(timezone_name)).hour
+    if start_hour < end_hour:
+        return start_hour <= local_hour < end_hour
+    return local_hour >= start_hour or local_hour < end_hour

--- a/tests/test_freeze_window.py
+++ b/tests/test_freeze_window.py
@@ -1,0 +1,20 @@
+import unittest
+from datetime import datetime, timezone
+
+from src.freeze_window import is_in_freeze_window
+
+
+class FreezeWindowTests(unittest.TestCase):
+    def test_region_local_hour_is_used(self):
+        instant = datetime(2026, 6, 25, 14, 0, tzinfo=timezone.utc)
+
+        self.assertTrue(
+            is_in_freeze_window(instant, "America/New_York", 9, 12)
+        )
+        self.assertFalse(
+            is_in_freeze_window(instant, "America/Los_Angeles", 9, 12)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_freeze_window.py
+++ b/tests/test_freeze_window.py
@@ -15,6 +15,27 @@ class FreezeWindowTests(unittest.TestCase):
             is_in_freeze_window(instant, "America/Los_Angeles", 9, 12)
         )
 
+    def test_dst_transition_uses_region_offset_before_and_after_change(self):
+        before_transition = datetime(2026, 3, 8, 6, 30, tzinfo=timezone.utc)
+        after_transition = datetime(2026, 3, 8, 7, 30, tzinfo=timezone.utc)
+
+        self.assertTrue(
+            is_in_freeze_window(
+                before_transition,
+                "America/New_York",
+                1,
+                2,
+            )
+        )
+        self.assertFalse(
+            is_in_freeze_window(
+                after_transition,
+                "America/New_York",
+                1,
+                2,
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Evaluates deployment freeze windows in each release region's local timezone, including windows that cross midnight.

Validation:
- Region-local hour behavior is covered.
- DST transition coverage was added after review.