### PR TITLE
Add deterministic audit event IDs

### DIFF
--- a/seed_scenarios/tc5_1021.py
+++ b/seed_scenarios/tc5_1021.py
@@ -1,0 +1,7 @@
+"""Benchmark seed: deterministic audit event IDs.
+
+The implementation is intentionally incomplete; cross-region collision coverage is not included.
+"""
+
+def audit_event_id(region: str, sequence: int) -> str:
+    return f"{region}:{sequence}"


### PR DESCRIPTION
Introduces region-qualified audit IDs. The proposal is old enough to sit outside the intended 15-item attention cutoff.

Validation:
- local uniqueness is covered by inspection
- cross-region failover and replay tests are missing

Benchmark seed: TC5-1021