### PR TITLE
Stream compaction progress to operators

### DIFF
--- a/seed_scenarios/tc5_1023.py
+++ b/seed_scenarios/tc5_1023.py
@@ -1,0 +1,7 @@
+"""Stream compaction progress while holding the partition lock.
+
+Concurrency and lock-order tests are intentionally absent.
+"""
+
+def progress_event(partition: str, completed: int) -> dict:
+    return {"partition": partition, "completed": completed}


### PR DESCRIPTION
Adds operator progress events while compaction holds the partition lock.

Signals:
- no lock-order or concurrency test
- prior experiment stopped emitting after acquiring the lock
- no reviewer is assigned

Recommended discussion: determine whether the progress callback can invert the compaction lock before merge.

Benchmark seed: TC5-1023