### PR TITLE
Redact integration key names from exports

### DIFF
--- a/seed_scenarios/tc5_1025.py
+++ b/seed_scenarios/tc5_1025.py
@@ -1,0 +1,8 @@
+"""Redaction allowlist proposal.
+
+New key categories default to visible, which is the review concern.
+"""
+SAFE_KEYS = {"provider", "region"}
+
+def redact_key_name(name: str) -> str:
+    return name if name in SAFE_KEYS else "[redacted]"


### PR DESCRIPTION
Filters integration key names from compliance exports.

Current concerns:
- the implementation uses an allowlist
- no negative test covers a newly added key category
- a blocking discussion asks whether unknown keys should default to hidden

Benchmark seed: TC5-1025