### PR TITLE
Upgrade object-store client after timeout fix

### DIFF
--- a/tests/test_benchmark_1030.py
+++ b/tests/test_benchmark_1030.py
@@ -1,0 +1,9 @@
+import unittest
+
+class ObjectStoreUpgradeSeedTests(unittest.TestCase):
+    def test_private_region_proxy_option_is_preserved(self):
+        observed_options = {"timeout": 30}
+        self.assertIn("proxy", observed_options, "new client dropped private-region proxy support")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Upgrades the storage client for a timeout fix.

Signals:
- the new version drops the proxy option used in private regions
- the required test deliberately captures the missing option and is red
- pinning avoids the break but leaves the timeout unresolved

Benchmark seed: TC5-1030