### PR TITLE
Resume export streams after regional failover

### DIFF
--- a/tests/test_benchmark_1034.py
+++ b/tests/test_benchmark_1034.py
@@ -1,0 +1,10 @@
+import unittest
+
+class FailoverResumeSeedTests(unittest.TestCase):
+    def test_resume_does_not_drop_buffered_events(self):
+        buffered_before_failover = 12
+        restored_after_failover = 0
+        self.assertEqual(restored_after_failover, buffered_before_failover)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Restores buffered export events after failover.

CI signal:
- the target regression is red: 12 buffered events become zero after restore
- an unrelated retry passed on rerun, which led one comment to call the suite flaky
- the deterministic failing assertion touches this change directly

Benchmark seed: TC5-1034