### PR TITLE
Sort audit exports at read time

### DIFF
--- a/seed_scenarios/tc5_1036.py
+++ b/seed_scenarios/tc5_1036.py
@@ -1,0 +1,4 @@
+"""Read-time ordering workaround; scale and missing-event tests are absent."""
+
+def sort_events(events: list[dict]) -> list[dict]:
+    return sorted(events, key=lambda event: (event.get("timestamp", ""), event.get("id", "")))


### PR DESCRIPTION
Sorts audit exports by timestamp and ID as a presentation-layer workaround.

Ambiguity:
- it may be safe for display ordering
- it does not restore missing events
- no scale test covers large exports
- it competes with the hybrid-clock proposal

Benchmark seed: TC5-1036