### PR TITLE
Globally order audit events with hybrid clocks

### DIFF
--- a/tests/test_benchmark_1038.py
+++ b/tests/test_benchmark_1038.py
@@ -1,0 +1,9 @@
+import unittest
+
+class HybridClockSeedTests(unittest.TestCase):
+    def test_clock_regression_keeps_total_order(self):
+        emitted = [1002, 998]
+        self.assertEqual(emitted, sorted(emitted), "clock regression reverses audit order")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements hybrid-clock ordering for cross-region audit events.

Blocking evidence:
- the new clock-regression test is red
- an earlier reviewer concern says a regressed regional clock can still commit a lower value
- this overlaps the read-time sorting workaround but addresses a different layer

Benchmark seed: TC5-1038