### PR TITLE
Add region field to audit event metrics

### DIFF
--- a/tests/test_benchmark_1039.py
+++ b/tests/test_benchmark_1039.py
@@ -1,0 +1,9 @@
+import unittest
+
+class AuditRegionMetricsSeedTests(unittest.TestCase):
+    def test_region_dimension_is_present(self):
+        metric = {"region": "sa-east-1", "events": 3}
+        self.assertEqual(metric["region"], "sa-east-1")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a region dimension to audit event metrics.

Status:
- focused passing test
- current scope is observability only
- owner is active
- no blocker or competing implementation

This is a healthy distractor.

Benchmark seed: TC5-1039