### PR TITLE
Normalize CLI completion timestamps to UTC

### DIFF
--- a/seed_review/review_402.py
+++ b/seed_review/review_402.py
@@ -1,4 +1,7 @@
-"""Initial CLI status timestamp formatter."""
+"""Render CLI completion timestamps in explicit UTC."""
+
+from datetime import datetime, timezone
 
 def display_completed_at(value: str) -> str:
-    return value.replace("+00:00", "")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/seed_review/review_402.py
+++ b/seed_review/review_402.py
@@ -1,0 +1,4 @@
+"""Initial CLI status timestamp formatter."""
+
+def display_completed_at(value: str) -> str:
+    return value.replace("+00:00", "")


### PR DESCRIPTION
Normalizes export completion timestamps before the CLI renders reconnect status.

The change is limited to display formatting. The API payload and cache TTL are unchanged.

Seed scenario: review-402