### PR TITLE
Recheck legal hold before asynchronous partition deletion

### DIFF
--- a/seed_review/review_403.py
+++ b/seed_review/review_403.py
@@ -1,0 +1,8 @@
+"""Queue expired partitions for asynchronous deletion."""
+
+def queue_expired(partition: dict, delete_queue: list[str]) -> None:
+    if not partition.get("expired"):
+        return
+    if partition.get("legal_hold"):
+        return
+    delete_queue.append(partition["id"])


### PR DESCRIPTION
Queues expired audit partitions for asynchronous deletion while honoring legal hold at enqueue time.

The dequeue worker is unchanged. Review must decide whether the hold needs to be checked again immediately before deletion.

Seed scenario: review-403