### PR TITLE
Rename notification delivery metrics

### DIFF
--- a/seed_review/review_404.py
+++ b/seed_review/review_404.py
@@ -1,0 +1,4 @@
+"""Notification delivery metric names."""
+
+DELIVERY_METRIC = "notification.delivery.completed"
+DELIVERY_FAILURE_METRIC = "notification.delivery.failed"


### PR DESCRIPTION
Renames notification delivery metrics to match the operations dashboard convention.

Runtime delivery behavior is unchanged. The patch contains only constant-name updates; no reviewer or check has requested additional test work.

Seed scenario: review-404