### PR TITLE
Persist webhook replay cursor before dispatch

### DIFF
--- a/seed_review/review_405.py
+++ b/seed_review/review_405.py
@@ -1,0 +1,5 @@
+"""Persist a replay cursor before dispatch."""
+
+def prepare_replay(cursor_store: dict, stream: str, cursor: str) -> dict:
+    cursor_store[stream] = cursor
+    return {"stream": stream, "cursor": cursor, "status": "ready"}


### PR DESCRIPTION
Persists the webhook replay cursor before dispatch so a worker restart can resume.

An older design approval covered in-memory cursor advancement. The persisted write ordering and idempotency semantics were added afterward.

Seed scenario: review-405