### PR TITLE
Normalize release approval timestamps before persistence

### DIFF
--- a/seed_merged/merged_601.py
+++ b/seed_merged/merged_601.py
@@ -1,0 +1,7 @@
+"""Normalize release approval timestamps before persistence."""
+
+from datetime import datetime, timezone
+
+def normalize_approval_time(value: str) -> str:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")


### PR DESCRIPTION
Normalizes approval timestamps to explicit UTC before persistence.

Merged scope:
- parsing accepts offsets and `Z`
- persisted values use one UTC representation
- existing records are read compatibly

Review conclusion: the change is complete. No migration, rollout, or documentation follow-up remains.

Seed scenario: merged-601