### PR TITLE
Bound webhook replay batches by workspace limit

### DIFF
--- a/seed_merged/merged_602.py
+++ b/seed_merged/merged_602.py
@@ -1,0 +1,6 @@
+"""Bound direct webhook replay batches by workspace limit."""
+
+def bounded_batch(events: list[dict], workspace_limit: int) -> list[dict]:
+    if workspace_limit < 0:
+        raise ValueError("workspace limit cannot be negative")
+    return events[:workspace_limit]


### PR DESCRIPTION
Caps direct webhook replay batches at the workspace-configured limit.

Merged scope:
- direct replay requests honor explicit zero and positive limits
- negative limits are rejected
- oversized event lists are truncated

Accepted follow-up: the background worker still reconstructs its batch limit from a persisted policy and can fall back to the legacy default after reload. That assembled-worker path is not changed here.

Seed scenario: merged-602