### PR TITLE
Emit audit export completion watermark

### DIFF
--- a/seed_merged/merged_603.py
+++ b/seed_merged/merged_603.py
@@ -1,0 +1,4 @@
+"""Emit a completion watermark for newly generated audit exports."""
+
+def completion_watermark(export_id: str, sequence: int) -> dict:
+    return {"export_id": export_id, "watermark": sequence, "version": 1}


### PR DESCRIPTION
Adds a versioned completion watermark to newly generated audit exports.

Merged scope:
- new exports emit a watermark
- consumers can read version 1
- existing export generation remains compatible

Accepted follow-up: historical exports have no watermark. Operations requested a bounded backfill plan and validation sample before enabling watermark-based reconciliation for older artifacts.

Seed scenario: merged-603