### PR TITLE
Use durable keys for export completion notifications

### DIFF
--- a/seed_merged/merged_604.py
+++ b/seed_merged/merged_604.py
@@ -1,0 +1,4 @@
+"""Use durable notification idempotency keys."""
+
+def delivery_key(export_id: str, notification_kind: str) -> str:
+    return f"{export_id}:{notification_kind}"


### PR DESCRIPTION
Uses durable export-and-notification keys to suppress duplicate completion notifications.

Merged scope:
- newly emitted completion notifications use durable keys
- callback replay reuses the same key
- existing delivery behavior is preserved

A cancelled Redis-key experiment explored a different design and should remain cancelled. Remaining follow-up is rollout monitoring plus cleanup of legacy key records after the observation window.

Seed scenario: merged-604