### PR TITLE
Cache policy snapshots by workspace version

### DIFF
--- a/seed_merged/merged_606.py
+++ b/seed_merged/merged_606.py
@@ -1,0 +1,8 @@
+"""Cache policy snapshots by workspace and version."""
+
+_POLICY_CACHE: dict[tuple[str, int], dict] = {}
+
+def cache_policy(workspace_id: str, version: int, policy: dict) -> dict:
+    key = (workspace_id, version)
+    _POLICY_CACHE[key] = dict(policy)
+    return _POLICY_CACHE[key]


### PR DESCRIPTION
Caches policy snapshots by workspace and version for repeated export operations.

Merged scope:
- same workspace/version reuses a snapshot
- a new version loads a new snapshot
- workspaces remain isolated

Accepted follow-up: long-lived workers need eviction metrics and a high-version-churn observation before memory behavior is considered closed. Correctness of the merged cache key is not in question.

Seed scenario: merged-606