### PR TITLE
EXP-258: reject blank version in build_release_marker

### DIFF
--- a/src/tc1_service.py
+++ b/src/tc1_service.py
@@ -110,6 +110,9 @@ def summarize_signals_for_handoff(
 
 
 def build_release_marker(version: str, channel: str) -> str:
+    version = version.strip()
+    if not version:
+        raise ValueError("release marker version must not be blank")
     if "-" in version:
         raise ValueError(
             "release marker version must not contain '-' (reserved field delimiter)"

--- a/tests/test_release_marker_blank_version.py
+++ b/tests/test_release_marker_blank_version.py
@@ -1,0 +1,19 @@
+from src.tc1_service import build_release_marker, parse_release_marker
+
+import pytest
+
+
+def test_build_release_marker_rejects_blank_version():
+    with pytest.raises(ValueError, match="must not be blank"):
+        build_release_marker("   ", "internal")
+
+
+def test_build_release_marker_rejects_empty_version():
+    with pytest.raises(ValueError, match="must not be blank"):
+        build_release_marker("", "internal")
+
+
+def test_build_release_marker_trims_surrounding_whitespace_in_version():
+    marker = build_release_marker("  2026.05.25  ", "internal")
+    assert marker.startswith("2026.05.25-internal-")
+    assert parse_release_marker(marker).version == "2026.05.25"


### PR DESCRIPTION
Fixes the build/parse asymmetry in build_release_marker: a blank/whitespace-only version now raises ValueError("release marker version must not be blank") before the existing '-' guard, and the version is stripped so valid values still round-trip.

Adds regression coverage in tests/test_release_marker_blank_version.py (test file added in a follow-up commit on this branch).

Ticket: EXP-258