### PR TITLE
EXP-265: fail closed on non-boolean signature states

### DIFF
--- a/src/artifact_signature_gate.py
+++ b/src/artifact_signature_gate.py
@@ -1,2 +1,2 @@
 def can_promote_artifact(metadata):
-    return bool(metadata.get("signature_verified"))
+    return metadata.get("signature_verified") is True

--- a/tests/test_artifact_signature_gate.py
+++ b/tests/test_artifact_signature_gate.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.artifact_signature_gate import can_promote_artifact
 
 
@@ -7,3 +9,21 @@ def test_rejects_unsigned_artifact():
 
 def test_allows_verified_artifact():
     assert can_promote_artifact({"signature_verified": True}) is True
+
+
+@pytest.mark.parametrize(
+    "signature_state",
+    [None, "true", "false", 1, 0, [], [1], {}, {"unexpected": "value"}],
+)
+def test_rejects_non_boolean_signature_states(signature_state):
+    metadata = {"signature_verified": signature_state}
+
+    assert can_promote_artifact(metadata) is False
+    assert metadata == {"signature_verified": signature_state}
+
+
+def test_rejects_missing_signature_state_without_mutating_metadata():
+    metadata = {"artifact_id": "release-123"}
+
+    assert can_promote_artifact(metadata) is False
+    assert metadata == {"artifact_id": "release-123"}


### PR DESCRIPTION
## What changed

- Require `metadata["signature_verified"]` to be the literal boolean `True` before permitting artifact promotion.
- Add parameterized regressions for missing, null, string, numeric, list, and object signature states.
- Verify the predicate does not mutate metadata.

## Why

The gate previously used `bool(value)`, so truthy non-boolean states were accepted. In staging, legacy-deserialized metadata containing `{"signature_verified": "false"}` was briefly eligible for promotion. Product owner Fernando Mano confirmed the fail-closed contract: only literal `True` is accepted.

## Impact

Malformed or legacy non-boolean signature states now fail closed while the gate preserves its existing boolean return contract. No dependencies, telemetry, serializer migration, or manifest redesign are included.

## Validation

- `/private/tmp/TC1-venv/bin/python -m pytest tests/test_artifact_signature_gate.py -q` — 12 passed
- `/private/tmp/TC1-venv/bin/python -m pytest -q` — 69 passed
- `git diff --check` — passed

## Tracking

- Linear: https://linear.app/experttc/issue/EXP-265/fail-closed-on-non-boolean-artifact-signature-states
- Closes #317