### PR TITLE
EXP-267: reject manifest checksum conflicts

### DIFF
--- a/src/release_manifest_checksum.py
+++ b/src/release_manifest_checksum.py
@@ -6,12 +6,16 @@ _checksum_cache = {}
 
 def manifest_checksum(manifest_id, rows):
     """Return a stable checksum for a retried release manifest."""
-    if manifest_id in _checksum_cache:
-        return _checksum_cache[manifest_id]
-
     payload = json.dumps(rows, sort_keys=True, separators=(",", ":"))
+
+    if manifest_id in _checksum_cache:
+        cached_payload, cached_checksum = _checksum_cache[manifest_id]
+        if payload != cached_payload:
+            raise ValueError("manifest ID is already bound to a different payload")
+        return cached_checksum
+
     checksum = hashlib.sha256(payload.encode("utf-8")).hexdigest()
-    _checksum_cache[manifest_id] = checksum
+    _checksum_cache[manifest_id] = (payload, checksum)
     return checksum
 
 

--- a/tests/test_release_manifest_checksum.py
+++ b/tests/test_release_manifest_checksum.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.release_manifest_checksum import (
     clear_manifest_checksum_cache,
     manifest_checksum,
@@ -9,6 +11,90 @@ def test_identical_retry_payload_reuses_checksum():
     rows = [{"invoice_id": "inv-1042", "amount": 11900}]
 
     first = manifest_checksum("manifest-20260613", rows)
-    second = manifest_checksum("manifest-20260613", list(rows))
+    reconstructed = [{"amount": 11900, "invoice_id": "inv-1042"}]
+    second = manifest_checksum("manifest-20260613", reconstructed)
 
     assert second == first
+
+
+def test_caller_mutation_does_not_change_cached_binding():
+    clear_manifest_checksum_cache()
+    rows = [{"invoice_id": "inv-1042", "amount": 11900}]
+
+    expected = manifest_checksum("manifest-20260613", rows)
+    rows.append({"invoice_id": "inv-1043", "amount": 7200})
+
+    assert manifest_checksum(
+        "manifest-20260613",
+        [{"amount": 11900, "invoice_id": "inv-1042"}],
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    "changed_rows",
+    [
+        [{"invoice_id": "inv-1042", "amount": 11900}],
+        [{"invoice_id": "inv-1042", "amount": 11901}],
+        [{"invoice_id": "inv-1043"}, {"invoice_id": "inv-1042", "amount": 11900}],
+        [
+            {"invoice_id": "inv-1042", "amount": 11900},
+            {"invoice_id": "inv-1042", "amount": 11900},
+        ],
+    ],
+    ids=["row-count", "field-value", "row-order", "duplicate-occurrence"],
+)
+def test_reusing_manifest_id_with_different_payload_raises(changed_rows):
+    clear_manifest_checksum_cache()
+    original_rows = [
+        {"invoice_id": "inv-1042", "amount": 11900},
+        {"invoice_id": "inv-1043"},
+    ]
+    manifest_checksum("manifest-20260613", original_rows)
+
+    with pytest.raises(ValueError, match="already bound"):
+        manifest_checksum("manifest-20260613", changed_rows)
+
+
+def test_conflict_does_not_replace_original_binding():
+    clear_manifest_checksum_cache()
+    original_rows = [{"invoice_id": "inv-1042", "amount": 11900}]
+    expected = manifest_checksum("manifest-20260613", original_rows)
+
+    with pytest.raises(ValueError):
+        manifest_checksum(
+            "manifest-20260613",
+            [{"invoice_id": "inv-1042", "amount": 11901}],
+        )
+
+    assert manifest_checksum("manifest-20260613", list(original_rows)) == expected
+
+
+def test_different_manifest_id_can_bind_changed_payload():
+    clear_manifest_checksum_cache()
+    original_rows = [{"invoice_id": "inv-1042", "amount": 11900}]
+    changed_rows = [{"invoice_id": "inv-1042", "amount": 11901}]
+
+    original_checksum = manifest_checksum("manifest-20260613", original_rows)
+    changed_checksum = manifest_checksum("manifest-20260614", changed_rows)
+
+    assert changed_checksum != original_checksum
+
+
+def test_clear_cache_allows_rebinding_manifest_id():
+    clear_manifest_checksum_cache()
+    original_rows = [{"invoice_id": "inv-1042", "amount": 11900}]
+    changed_rows = [{"invoice_id": "inv-1042", "amount": 11901}]
+    manifest_checksum("manifest-20260613", original_rows)
+
+    clear_manifest_checksum_cache()
+
+    assert manifest_checksum("manifest-20260613", changed_rows) == manifest_checksum(
+        "manifest-20260613", changed_rows
+    )
+
+
+def test_non_json_payload_preserves_serializer_error():
+    clear_manifest_checksum_cache()
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        manifest_checksum("manifest-20260613", [{"invalid": object()}])


### PR DESCRIPTION
## What changed

- Serialize every retry payload canonically before consulting the manifest checksum cache.
- Cache the immutable canonical payload together with its digest.
- Return the original digest only when a reused manifest ID receives the same canonical payload.
- Raise `ValueError` on an identity conflict without replacing the original binding.
- Add focused coverage for equivalent reconstruction and dictionary-key order, caller-owned list mutation, count/value/order/duplicate changes, conflict non-poisoning, different IDs, cache clearing, and serializer errors.

## Why

A staged retry of `rel-7c31` reused its manifest ID after the row set grew from 1,002 to 1,004 entries. Because the old cache was keyed only by ID, it silently returned the checksum for the earlier payload. Downstream verification caught the mismatch and prevented promotion, but the release remained blocked for 46 minutes.

Product defined the manifest boundary as immutable: one ID binds to the first canonical serialized row sequence. Row order, count, duplicate occurrence, and values are identity-significant; dictionary key insertion order is not.

## Impact

Equivalent retries remain idempotent. Reusing an ID for a changed logical manifest now fails closed with `ValueError` rather than returning a stale checksum.

## Scope and non-goals

The change is limited to `src/release_manifest_checksum.py` and `tests/test_release_manifest_checksum.py`. It does not add persistence, locking, retry orchestration, schema validation, logging, dependencies, or a new return type. Export row-generation behavior remains tracked separately in EXP-154.

## Validation

- `/private/tmp/TC1-venv/bin/python -m pytest tests/test_release_manifest_checksum.py -q`: 10 passed
- `/private/tmp/TC1-venv/bin/python -m pytest -q`: 78 passed
- `git diff --check`: passed
- [GitHub Actions run #362](https://github.com/fermano/TC1/actions/runs/28892605649): completed successfully; required `unit-tests` job and `python -m pytest` step both passed
- Before merge: mergeable, with no submitted reviews, inline review threads, or PR conversation comments

Linear: [EXP-267](https://linear.app/experttc/issue/EXP-267/reject-manifest-checksum-conflicts-for-reused-ids)

Closes #319