### PR TITLE
Adopt immutable handoff records at the intake boundary

### DIFF
--- a/docs/intake-service.md
+++ b/docs/intake-service.md
@@ -3,7 +3,12 @@
 The intake helpers keep support handoff parsing separate from release coordination code.
 
 - Queue retry settings may be inherited from workspace configuration.
-- Handoff rows remain in the order copied from support notes.
+- Handoff records remain in the order copied from support notes.
 - Release markers are normalized before they are included in status updates.
+
+Intake now emits immutable `HandoffRecord` values with a canonical `signal_id`.
+Filtering normalizes severity, owner, identifier, and summary values and returns
+records rather than exposing caller-owned dictionaries to downstream release
+coordination code.
 
 Changes to these helpers should stay focused and include regression coverage for edge cases.

--- a/src/handoff_models.py
+++ b/src/handoff_models.py
@@ -1,0 +1,13 @@
+"""Canonical release-handoff records shared by intake and reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HandoffRecord:
+    signal_id: str | None
+    owner: str
+    severity: str
+    summary: str

--- a/src/intake_service.py
+++ b/src/intake_service.py
@@ -3,13 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TypedDict
-
-
-class HandoffRow(TypedDict):
-    owner: str
-    severity: str
-    summary: str
+from src.handoff_models import HandoffRecord
 
 
 SEVERITY_RANK = {
@@ -26,22 +20,33 @@ def resolve_retry_budget(requested: int | None, default: int) -> int:
 
 
 def filter_handoff_rows(
-    rows: Iterable[HandoffRow],
+    rows: Iterable[HandoffRecord],
     *,
     minimum_severity: str | None = None,
-) -> list[HandoffRow]:
-    """Return handoff rows in the order copied from support notes."""
-    row_list = list(rows)
+    owner_fallback: str = "unassigned",
+) -> list[HandoffRecord]:
+    """Normalize canonical handoff records and filter without reordering."""
+    fallback = owner_fallback.strip() or "unassigned"
+    row_list = [
+        HandoffRecord(
+            signal_id=row.signal_id.strip() if row.signal_id else None,
+            owner=row.owner.strip() or fallback,
+            severity=row.severity.strip().lower(),
+            summary=row.summary.strip(),
+        )
+        for row in rows
+    ]
     if minimum_severity is None:
         return row_list
-    if minimum_severity not in SEVERITY_RANK:
+    threshold = minimum_severity.strip().lower()
+    if threshold not in SEVERITY_RANK:
         raise ValueError(f"unknown minimum severity: {minimum_severity}")
 
-    minimum_rank = SEVERITY_RANK[minimum_severity]
+    minimum_rank = SEVERITY_RANK[threshold]
     return [
         row
         for row in row_list
-        if SEVERITY_RANK.get(row["severity"], 0) >= minimum_rank
+        if SEVERITY_RANK.get(row.severity, 0) >= minimum_rank
     ]
 
 

--- a/tests/test_handoff_models.py
+++ b/tests/test_handoff_models.py
@@ -1,0 +1,21 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.handoff_models import HandoffRecord
+
+
+def test_handoff_record_equality_uses_all_canonical_fields() -> None:
+    first = HandoffRecord("evt-1", "release", "high", "Queue delay")
+    same = HandoffRecord("evt-1", "release", "high", "Queue delay")
+    changed = HandoffRecord("evt-1", "release", "critical", "Queue delay")
+
+    assert same == first
+    assert changed != first
+
+
+def test_handoff_record_is_immutable() -> None:
+    record = HandoffRecord("evt-1", "release", "high", "Queue delay")
+
+    with pytest.raises(FrozenInstanceError):
+        record.severity = "critical"

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -1,5 +1,6 @@
 import pytest
 
+from src.handoff_models import HandoffRecord
 from src.intake_service import (
     extract_release_marker,
     filter_handoff_rows,
@@ -21,8 +22,8 @@ def test_retry_budget_accepts_positive_override() -> None:
 
 def test_handoff_rows_keep_input_order() -> None:
     rows = [
-        {"owner": "platform", "severity": "high", "summary": "Queue delay"},
-        {"owner": "support", "severity": "low", "summary": "Copy cleanup"},
+        HandoffRecord("evt-1", "platform", "high", "Queue delay"),
+        HandoffRecord("evt-2", "support", "low", "Copy cleanup"),
     ]
 
     assert filter_handoff_rows(rows) == rows
@@ -30,24 +31,42 @@ def test_handoff_rows_keep_input_order() -> None:
 
 def test_handoff_rows_filter_by_minimum_severity_in_input_order() -> None:
     rows = [
-        {"owner": "platform", "severity": "medium", "summary": "Queue delay"},
-        {"owner": "support", "severity": "low", "summary": "Copy cleanup"},
-        {"owner": "release", "severity": "critical", "summary": "Escalation"},
-        {"owner": "docs", "severity": "unknown", "summary": "Draft note"},
+        HandoffRecord("evt-1", "platform", "medium", "Queue delay"),
+        HandoffRecord("evt-2", "support", "low", "Copy cleanup"),
+        HandoffRecord("evt-3", "release", "critical", "Escalation"),
+        HandoffRecord("evt-4", "docs", "unknown", "Draft note"),
     ]
 
     assert filter_handoff_rows(rows, minimum_severity="high") == [
-        {"owner": "release", "severity": "critical", "summary": "Escalation"},
+        HandoffRecord("evt-3", "release", "critical", "Escalation"),
     ]
 
 
 def test_handoff_rows_reject_unknown_minimum_severity() -> None:
     rows = [
-        {"owner": "platform", "severity": "medium", "summary": "Queue delay"},
+        HandoffRecord("evt-1", "platform", "medium", "Queue delay"),
     ]
 
     with pytest.raises(ValueError, match="unknown minimum severity"):
         filter_handoff_rows(rows, minimum_severity="urgent")
+
+
+def test_handoff_rows_normalize_severity_owner_and_summary() -> None:
+    rows = [
+        HandoffRecord(" evt-1 ", "   ", " HIGH ", "  Queue delay  "),
+    ]
+
+    assert filter_handoff_rows(rows, owner_fallback="release-ops") == [
+        HandoffRecord("evt-1", "release-ops", "high", "Queue delay"),
+    ]
+
+
+def test_handoff_rows_accept_normalized_threshold() -> None:
+    rows = [HandoffRecord("evt-1", "release", "CRITICAL", "Escalation")]
+
+    assert filter_handoff_rows(rows, minimum_severity=" High ") == [
+        HandoffRecord("evt-1", "release", "critical", "Escalation")
+    ]
 
 
 def test_release_marker_trims_surrounding_whitespace() -> None:


### PR DESCRIPTION
Refactors TC1 intake handoffs around a canonical immutable `HandoffRecord`.

Scope:
- introduce `signal_id` as the canonical record identifier
- normalize identifier, owner, severity, and summary during intake
- preserve input order and severity filtering
- return immutable records rather than caller-owned dictionaries
- document the record boundary and add focused coverage

Compatibility note: direct dictionary inputs are intentionally removed from this refactor; Support was expected to migrate its exporter separately.

Seed scenario: integration-history-901