### PR TITLE
Collapse repeated support event IDs in intake

### DIFF
--- a/src/intake_service.py
+++ b/src/intake_service.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 class HandoffRow(TypedDict):
     owner: str
     severity: str
     summary: str
+    event_id: NotRequired[str]
 
 
 SEVERITY_RANK = {
@@ -29,20 +30,34 @@ def filter_handoff_rows(
     rows: Iterable[HandoffRow],
     *,
     minimum_severity: str | None = None,
+    collapse_retries: bool = False,
 ) -> list[HandoffRow]:
-    """Return handoff rows in the order copied from support notes."""
+    """Filter handoff rows and optionally collapse replayed event IDs."""
     row_list = list(rows)
-    if minimum_severity is None:
-        return row_list
-    if minimum_severity not in SEVERITY_RANK:
-        raise ValueError(f"unknown minimum severity: {minimum_severity}")
+    if minimum_severity is not None:
+        if minimum_severity not in SEVERITY_RANK:
+            raise ValueError(f"unknown minimum severity: {minimum_severity}")
 
-    minimum_rank = SEVERITY_RANK[minimum_severity]
-    return [
-        row
-        for row in row_list
-        if SEVERITY_RANK.get(row["severity"], 0) >= minimum_rank
-    ]
+        minimum_rank = SEVERITY_RANK[minimum_severity]
+        row_list = [
+            row
+            for row in row_list
+            if SEVERITY_RANK.get(row["severity"], 0) >= minimum_rank
+        ]
+
+    if not collapse_retries:
+        return row_list
+
+    collapsed: list[HandoffRow] = []
+    seen_event_ids: set[str] = set()
+    for row in row_list:
+        event_id = row.get("event_id", "").strip()
+        if event_id:
+            if event_id in seen_event_ids:
+                continue
+            seen_event_ids.add(event_id)
+        collapsed.append(row)
+    return collapsed
 
 
 def extract_release_marker(note: str) -> str:


### PR DESCRIPTION
Prototype for suppressing duplicate handoff rows after Support delivery retries.

The prototype keeps the first dictionary row for each non-blank `event_id` and preserves rows without identifiers. Tests and migration notes were not yet included.

Closed after the immutable `HandoffRecord` refactor merged and offline review identified unresolved field-precedence and identifier-compatibility requirements. Continued work, if accepted, belongs on the three-commit `seed/handoff-retry-collapse-legacy` branch rather than this one-commit prototype.

Seed scenario: integration-review-902