### PR TITLE
EXP-272: reconcile replayed handoff corrections

### DIFF
--- a/docs/intake-service.md
+++ b/docs/intake-service.md
@@ -11,4 +11,15 @@ Filtering normalizes severity, owner, identifier, and summary values and returns
 records rather than exposing caller-owned dictionaries to downstream release
 coordination code.
 
+During the Support cutover, intake also accepts legacy dictionaries that use
+`event_id` or `signal_id`. When both are present, their non-blank trimmed values
+must match. Every accepted input still produces an immutable `HandoffRecord`.
+
+Callers may opt into replay reconciliation with
+`filter_handoff_rows(..., collapse_retries=True)`. Repeated non-blank identifiers
+keep their first list position while later copies contribute the highest known
+severity and the latest non-blank owner and summary. Missing or blank identifiers
+remain separate because TC1 cannot establish their identity. Severity filtering
+runs after replay reconciliation so a corrected escalation is not hidden.
+
 Changes to these helpers should stay focused and include regression coverage for edge cases.

--- a/src/intake_service.py
+++ b/src/intake_service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import TypedDict, Union
+
 from src.handoff_models import HandoffRecord
 
 
@@ -14,28 +16,49 @@ SEVERITY_RANK = {
 }
 
 
+class _LegacyHandoffRequired(TypedDict):
+    owner: str
+    severity: str
+    summary: str
+
+
+class LegacyHandoffRow(_LegacyHandoffRequired, total=False):
+    event_id: str | None
+    signal_id: str | None
+
+
+HandoffInput = Union[HandoffRecord, LegacyHandoffRow]
+
+
 def resolve_retry_budget(requested: int | None, default: int) -> int:
     """Return the configured retry count unless a request overrides it."""
     return default if requested is None else requested
 
 
 def filter_handoff_rows(
-    rows: Iterable[HandoffRecord],
+    rows: Iterable[HandoffInput],
     *,
     minimum_severity: str | None = None,
     owner_fallback: str = "unassigned",
+    collapse_retries: bool = False,
 ) -> list[HandoffRecord]:
-    """Normalize canonical handoff records and filter without reordering."""
+    """Normalize handoff records and optionally merge replayed corrections."""
     fallback = owner_fallback.strip() or "unassigned"
+    row_list = [_normalize_handoff_row(row) for row in rows]
+
+    if collapse_retries:
+        row_list = _collapse_retries(row_list)
+
     row_list = [
         HandoffRecord(
-            signal_id=row.signal_id.strip() if row.signal_id else None,
-            owner=row.owner.strip() or fallback,
-            severity=row.severity.strip().lower(),
-            summary=row.summary.strip(),
+            signal_id=row.signal_id,
+            owner=row.owner or fallback,
+            severity=row.severity,
+            summary=row.summary,
         )
-        for row in rows
+        for row in row_list
     ]
+
     if minimum_severity is None:
         return row_list
     threshold = minimum_severity.strip().lower()
@@ -48,6 +71,70 @@ def filter_handoff_rows(
         for row in row_list
         if SEVERITY_RANK.get(row.severity, 0) >= minimum_rank
     ]
+
+
+def _normalize_handoff_row(row: HandoffInput) -> HandoffRecord:
+    if isinstance(row, HandoffRecord):
+        signal_id = row.signal_id.strip() if row.signal_id else None
+        owner = row.owner
+        severity = row.severity
+        summary = row.summary
+    else:
+        signal_id = _legacy_signal_id(row)
+        owner = row["owner"]
+        severity = row["severity"]
+        summary = row["summary"]
+
+    return HandoffRecord(
+        signal_id=signal_id,
+        owner=owner.strip(),
+        severity=severity.strip().lower(),
+        summary=summary.strip(),
+    )
+
+
+def _legacy_signal_id(row: LegacyHandoffRow) -> str | None:
+    signal_id = row.get("signal_id")
+    event_id = row.get("event_id")
+    normalized_signal_id = signal_id.strip() if signal_id is not None else ""
+    normalized_event_id = event_id.strip() if event_id is not None else ""
+
+    if (
+        normalized_signal_id
+        and normalized_event_id
+        and normalized_signal_id != normalized_event_id
+    ):
+        raise ValueError("legacy handoff row has conflicting signal_id and event_id")
+
+    return normalized_signal_id or normalized_event_id or None
+
+
+def _collapse_retries(rows: list[HandoffRecord]) -> list[HandoffRecord]:
+    collapsed: list[HandoffRecord] = []
+    index_by_signal_id: dict[str, int] = {}
+
+    for row in rows:
+        if row.signal_id is None:
+            collapsed.append(row)
+            continue
+
+        existing_index = index_by_signal_id.get(row.signal_id)
+        if existing_index is None:
+            index_by_signal_id[row.signal_id] = len(collapsed)
+            collapsed.append(row)
+            continue
+
+        existing = collapsed[existing_index]
+        existing_rank = SEVERITY_RANK.get(existing.severity, 0)
+        row_rank = SEVERITY_RANK.get(row.severity, 0)
+        collapsed[existing_index] = HandoffRecord(
+            signal_id=existing.signal_id,
+            owner=row.owner or existing.owner,
+            severity=row.severity if row_rank > existing_rank else existing.severity,
+            summary=row.summary or existing.summary,
+        )
+
+    return collapsed
 
 
 def extract_release_marker(note: str) -> str:

--- a/tests/test_intake_service.py
+++ b/tests/test_intake_service.py
@@ -69,6 +69,179 @@ def test_handoff_rows_accept_normalized_threshold() -> None:
     ]
 
 
+def test_handoff_rows_accept_legacy_event_id_and_return_canonical_records() -> None:
+    rows = [
+        {
+            "event_id": " evt-17 ",
+            "owner": " platform ",
+            "severity": " HIGH ",
+            "summary": " Queue delay ",
+        }
+    ]
+
+    assert filter_handoff_rows(rows) == [
+        HandoffRecord("evt-17", "platform", "high", "Queue delay")
+    ]
+
+
+def test_handoff_rows_accept_matching_legacy_identifier_aliases() -> None:
+    rows = [
+        {
+            "event_id": " evt-17 ",
+            "signal_id": "evt-17",
+            "owner": "platform",
+            "severity": "high",
+            "summary": "Queue delay",
+        }
+    ]
+
+    assert filter_handoff_rows(rows)[0].signal_id == "evt-17"
+
+
+def test_handoff_rows_reject_conflicting_legacy_identifier_aliases() -> None:
+    rows = [
+        {
+            "event_id": "evt-17",
+            "signal_id": "evt-18",
+            "owner": "platform",
+            "severity": "high",
+            "summary": "Queue delay",
+        }
+    ]
+
+    with pytest.raises(ValueError, match="conflicting signal_id and event_id"):
+        filter_handoff_rows(rows)
+
+
+def test_handoff_rows_keep_retries_when_collapse_is_disabled() -> None:
+    rows = [
+        HandoffRecord("evt-17", "platform", "medium", "Preliminary"),
+        HandoffRecord("evt-17", "release", "critical", "Confirmed blocker"),
+    ]
+
+    assert filter_handoff_rows(rows) == rows
+
+
+def test_handoff_rows_merge_retries_in_first_seen_position() -> None:
+    rows = [
+        HandoffRecord("evt-17", "platform", "medium", "Preliminary"),
+        HandoffRecord("evt-22", "support", "high", "Separate event"),
+        HandoffRecord("evt-17", "release-ops", "critical", "Confirmed blocker"),
+    ]
+
+    assert filter_handoff_rows(rows, collapse_retries=True) == [
+        HandoffRecord("evt-17", "release-ops", "critical", "Confirmed blocker"),
+        HandoffRecord("evt-22", "support", "high", "Separate event"),
+    ]
+
+
+def test_handoff_rows_merge_canonical_and_legacy_retry_identifiers() -> None:
+    rows = [
+        HandoffRecord("evt-17", "platform", "medium", "Preliminary"),
+        {
+            "event_id": " evt-17 ",
+            "owner": "release-ops",
+            "severity": "critical",
+            "summary": "Confirmed blocker",
+        },
+    ]
+
+    assert filter_handoff_rows(rows, collapse_retries=True) == [
+        HandoffRecord("evt-17", "release-ops", "critical", "Confirmed blocker")
+    ]
+
+
+def test_handoff_rows_keep_highest_recognized_severity_and_latest_text() -> None:
+    rows = [
+        HandoffRecord("evt-17", "platform", "high", "Queue blocked"),
+        HandoffRecord("evt-17", "release-ops", "mystery", "Rollback approved"),
+        HandoffRecord("evt-17", "incident", "medium", "Recovery started"),
+    ]
+
+    assert filter_handoff_rows(rows, collapse_retries=True) == [
+        HandoffRecord("evt-17", "incident", "high", "Recovery started")
+    ]
+
+
+def test_handoff_rows_do_not_erase_text_with_blank_corrections() -> None:
+    rows = [
+        HandoffRecord("evt-17", "platform", "medium", "Queue delay"),
+        HandoffRecord("evt-17", "   ", "high", "   "),
+    ]
+
+    assert filter_handoff_rows(
+        rows,
+        owner_fallback="release-ops",
+        collapse_retries=True,
+    ) == [HandoffRecord("evt-17", "platform", "high", "Queue delay")]
+
+
+def test_handoff_rows_apply_owner_fallback_after_merging_blank_corrections() -> None:
+    rows = [
+        HandoffRecord("evt-17", "   ", "medium", "Queue delay"),
+        HandoffRecord("evt-17", "", "high", "Confirmed"),
+    ]
+
+    assert filter_handoff_rows(
+        rows,
+        owner_fallback="release-ops",
+        collapse_retries=True,
+    ) == [HandoffRecord("evt-17", "release-ops", "high", "Confirmed")]
+
+
+def test_handoff_rows_keep_missing_and_blank_identifiers_distinct() -> None:
+    rows = [
+        {
+            "owner": "support",
+            "severity": "low",
+            "summary": "Missing identifier",
+        },
+        {
+            "event_id": "   ",
+            "owner": "support",
+            "severity": "low",
+            "summary": "Blank identifier",
+        },
+    ]
+
+    assert filter_handoff_rows(rows, collapse_retries=True) == [
+        HandoffRecord(None, "support", "low", "Missing identifier"),
+        HandoffRecord(None, "support", "low", "Blank identifier"),
+    ]
+
+
+def test_handoff_rows_filter_merged_retries_by_final_severity() -> None:
+    rows = [
+        HandoffRecord("evt-17", "platform", "medium", "Preliminary"),
+        HandoffRecord("evt-17", "release-ops", "critical", "Confirmed blocker"),
+    ]
+
+    assert filter_handoff_rows(
+        rows,
+        minimum_severity="high",
+        collapse_retries=True,
+    ) == [HandoffRecord("evt-17", "release-ops", "critical", "Confirmed blocker")]
+
+
+def test_handoff_rows_keep_unknown_severity_without_a_threshold() -> None:
+    rows = [HandoffRecord("evt-17", "docs", " UNKNOWN ", "Draft note")]
+
+    assert filter_handoff_rows(rows, collapse_retries=True) == [
+        HandoffRecord("evt-17", "docs", "unknown", "Draft note")
+    ]
+
+
+def test_handoff_rows_preserve_missing_required_field_key_error() -> None:
+    malformed_row = {
+        "event_id": "evt-17",
+        "severity": "high",
+        "summary": "Missing owner",
+    }
+
+    with pytest.raises(KeyError, match="owner"):
+        filter_handoff_rows([malformed_row])  # type: ignore[list-item]
+
+
 def test_release_marker_trims_surrounding_whitespace() -> None:
     assert extract_release_marker("  20260530-rc2  ") == "20260530-rc2"
 


### PR DESCRIPTION
## Summary

- accept canonical `HandoffRecord` values and legacy handoff dictionaries while always returning normalized immutable records
- reconcile `event_id` / `signal_id` aliases and reject conflicting non-blank identifiers
- add opt-in replay collapse that preserves first-seen position, highest recognized severity, and the latest non-blank owner/summary
- apply severity filtering after replay reconciliation and document the cutover behavior

## Why

A Support reconnect replayed one logical handoff event with a later severity escalation and corrected owner/summary. Showing every copy made the handoff ambiguous, while the earlier first-row-wins prototype could hide the confirmed blocker.

The implementation preserves the canonical record architecture merged in #322 and reconciles the useful tests and documentation from `seed/handoff-retry-collapse-legacy` with the product decision that resolved #323's material review concern.

## User and developer impact

Callers that do not request collapse keep the existing ordered normalized output. Callers that opt in can safely fold replayed corrections without losing later escalations. The legacy dictionary path supports the August migration window without exposing mutable dictionaries downstream.

## Root cause

The old retry-collapse work was built against dictionary rows and kept the first replayed copy. Current `main` had canonical records but no dictionary compatibility or correction-folding policy, leaving identity aliases and post-retry field precedence unresolved.

## Validation

- `/private/tmp/TC1-venv/bin/python -m pytest -q tests/test_intake_service.py` — 24 passed
- `/private/tmp/TC1-venv/bin/python -m pytest -q` — 95 passed
- `/private/tmp/TC1-venv/bin/python scripts/verify_repo_baseline.py` — baseline ready
- `git diff --check` — passed
- required GitHub `unit-tests` job — passed in [CI run 28894927153](https://github.com/fermano/TC1/actions/runs/28894927153)

## Tracking and scope

- Linear: [EXP-272](https://linear.app/experttc/issue/EXP-272/collapse-replayed-handoff-corrections-at-the-canonical-intake-boundary)
- Addresses #324
- Related completed refactor: #322
- Closed prototype context: #323

Collapse metrics and discarded-payload storage remain out of scope because they have no committed owner or acceptance requirement.