### PR TITLE
Represent release-region selection with immutable policy decisions

### DIFF
--- a/docs/release-region-selection.md
+++ b/docs/release-region-selection.md
@@ -1,0 +1,9 @@
+# Release region selection
+
+TC1 records release selection as an immutable `RegionDecision` produced from a
+`RegionPolicy`. Aliases are canonicalized for requested, allowed, and default
+regions.
+
+A missing or blank request uses the policy default. An explicit region outside
+the allowlist is rejected rather than silently changing deployment geography.
+The default must itself belong to the normalized allowlist.

--- a/src/region_policy.py
+++ b/src/region_policy.py
@@ -1,0 +1,18 @@
+"""Immutable release-region policy and decision records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RegionPolicy:
+    allowed_regions: tuple[str, ...]
+    default_region: str
+
+
+@dataclass(frozen=True)
+class RegionDecision:
+    requested_region: str | None
+    selected_region: str
+    source: str

--- a/src/release_region.py
+++ b/src/release_region.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 REGION_ALIASES = {
     "us-east": "us-east-1",
     "use1": "us-east-1",
@@ -5,7 +8,26 @@ REGION_ALIASES = {
     "euw1": "eu-west-1",
 }
 
+from src.region_policy import RegionDecision, RegionPolicy
+
 
 def normalize_release_region(value):
     key = value.strip().lower()
     return REGION_ALIASES.get(key, key)
+
+
+def resolve_release_region(policy: RegionPolicy, value: str | None) -> RegionDecision:
+    """Select a canonical allowed region without silently changing geography."""
+    allowed = tuple(
+        dict.fromkeys(normalize_release_region(region) for region in policy.allowed_regions)
+    )
+    default = normalize_release_region(policy.default_region)
+    if default not in allowed:
+        raise ValueError("default region must be present in allowed regions")
+
+    requested = normalize_release_region(value) if value is not None else ""
+    if not requested:
+        return RegionDecision(None, default, "default")
+    if requested not in allowed:
+        raise ValueError(f"release region is not allowed: {requested}")
+    return RegionDecision(requested, requested, "requested")

--- a/tests/test_region_policy.py
+++ b/tests/test_region_policy.py
@@ -1,0 +1,19 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.region_policy import RegionDecision, RegionPolicy
+
+
+def test_region_policy_is_immutable():
+    policy = RegionPolicy(("us-east-1",), "us-east-1")
+
+    with pytest.raises(FrozenInstanceError):
+        policy.default_region = "eu-west-1"
+
+
+def test_region_decision_keeps_selection_source():
+    requested = RegionDecision("us-east-1", "us-east-1", "requested")
+    defaulted = RegionDecision(None, "us-east-1", "default")
+
+    assert requested != defaulted

--- a/tests/test_release_region.py
+++ b/tests/test_release_region.py
@@ -1,6 +1,42 @@
-from src.release_region import normalize_release_region
+import pytest
+
+from src.region_policy import RegionDecision, RegionPolicy
+from src.release_region import normalize_release_region, resolve_release_region
 
 
 def test_normalizes_supported_aliases():
     assert normalize_release_region(" USE1 ") == "us-east-1"
     assert normalize_release_region("eu-west") == "eu-west-1"
+
+
+def test_policy_selects_requested_alias_with_canonical_decision():
+    policy = RegionPolicy(("us-east", "eu-west-1"), "eu-west")
+
+    assert resolve_release_region(policy, " USE1 ") == RegionDecision(
+        "us-east-1", "us-east-1", "requested"
+    )
+
+
+def test_policy_uses_default_only_when_request_is_absent():
+    policy = RegionPolicy(("us-east-1", "eu-west-1"), "euw1")
+
+    assert resolve_release_region(policy, None) == RegionDecision(
+        None, "eu-west-1", "default"
+    )
+    assert resolve_release_region(policy, "   ") == RegionDecision(
+        None, "eu-west-1", "default"
+    )
+
+
+def test_policy_rejects_explicit_disallowed_region():
+    policy = RegionPolicy(("us-east-1", "eu-west-1"), "eu-west-1")
+
+    with pytest.raises(ValueError, match="not allowed"):
+        resolve_release_region(policy, "ap-south-1")
+
+
+def test_policy_rejects_default_outside_allowlist():
+    policy = RegionPolicy(("us-east-1",), "eu-west-1")
+
+    with pytest.raises(ValueError, match="default region"):
+        resolve_release_region(policy, None)


### PR DESCRIPTION
Refactors TC1 release-region selection around immutable `RegionPolicy` and `RegionDecision` records.

Scope:
- canonicalize aliases across allowed/default/requested regions
- use the policy default only for absent requests
- reject explicit disallowed geography
- preserve selection provenance in the decision record
- add policy and decision regression coverage

Compatibility note: the legacy three-argument string-returning helper was expected to be retired by its deployment-script owner.

Seed scenario: semantic-integration-1001