### PR TITLE
Fall back unsupported release requests to workspace default

### DIFF
--- a/src/release_region.py
+++ b/src/release_region.py
@@ -9,3 +9,18 @@ REGION_ALIASES = {
 def normalize_release_region(value):
     key = value.strip().lower()
     return REGION_ALIASES.get(key, key)
+
+
+def resolve_release_region(value, allowed_regions, default_region):
+    """Resolve a requested region against a legacy workspace allowlist."""
+    normalized_allowed = tuple(
+        dict.fromkeys(normalize_release_region(region) for region in allowed_regions)
+    )
+    normalized_default = normalize_release_region(default_region)
+    if normalized_default not in normalized_allowed:
+        raise ValueError("default region must be present in allowed regions")
+
+    requested = normalize_release_region(value) if value is not None else ""
+    if not requested or requested not in normalized_allowed:
+        return normalized_default
+    return requested


### PR DESCRIPTION
## Summary
This prototype resolves legacy deployment-region requests against a caller-provided allowlist and falls back to the workspace default when the request is blank or unsupported.

## Outcome
Closed without merge after review. Silent fallback for an explicitly unsupported region can violate the release-geography compliance boundary.

The accepted architectural direction is the immutable `RegionPolicy` / `RegionDecision` model in #326. Product communication indicates one deployment caller still requires the legacy three-argument call form and string return for one release; that compatibility behavior must be reconciled with #326 while rejecting explicit unsupported regions.

A later continuation on `seed/release-region-legacy-fallback` adds aliases, focused tests, and docs, but retains the rejected fallback behavior and has no open PR.

Telemetry was suggested as an optional separate follow-up; it has no agreed schema or owner.