### PR TITLE
Represent current export schemas as immutable snapshots

### DIFF
--- a/docs/export-schema-cache.md
+++ b/docs/export-schema-cache.md
@@ -1,0 +1,8 @@
+# Export schema snapshots
+
+TC1 keeps one immutable `SchemaSnapshot` per workspace. Repeated reads at the
+same workspace version reuse that snapshot. Any observed version change replaces
+the current entry rather than accumulating workspace history in the process.
+
+New integrations should depend on an `ExportSchemaCache` instance and consume
+the snapshot's `fields` tuple. Cache state is intentionally process-local.

--- a/src/export_schema_cache.py
+++ b/src/export_schema_cache.py
@@ -1,13 +1,36 @@
-_schema_cache = {}
+"""Current export-schema snapshots per workspace."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.export_schema_models import SchemaSnapshot
 
 
-def export_schema(workspace_id, workspace_version, fields):
-    if workspace_id in _schema_cache:
-        return _schema_cache[workspace_id]
-    schema = tuple(fields)
-    _schema_cache[workspace_id] = schema
-    return schema
+class ExportSchemaCache:
+    def __init__(self) -> None:
+        self._current: dict[str, SchemaSnapshot] = {}
+
+    def snapshot(
+        self,
+        workspace_id: str,
+        workspace_version: int,
+        fields: Iterable[str],
+    ) -> SchemaSnapshot:
+        current = self._current.get(workspace_id)
+        if current is not None and current.workspace_version == workspace_version:
+            return current
+
+        snapshot = SchemaSnapshot(workspace_id, workspace_version, tuple(fields))
+        self._current[workspace_id] = snapshot
+        return snapshot
+
+    def clear(self) -> None:
+        self._current.clear()
 
 
-def clear_export_schema_cache():
-    _schema_cache.clear()
+export_schema_cache = ExportSchemaCache()
+
+
+def clear_export_schema_cache() -> None:
+    export_schema_cache.clear()

--- a/src/export_schema_models.py
+++ b/src/export_schema_models.py
@@ -1,0 +1,12 @@
+"""Immutable export schema state used by cache consumers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SchemaSnapshot:
+    workspace_id: str
+    workspace_version: int
+    fields: tuple[str, ...]

--- a/tests/test_export_schema_cache.py
+++ b/tests/test_export_schema_cache.py
@@ -1,9 +1,31 @@
-from src.export_schema_cache import clear_export_schema_cache, export_schema
+from src.export_schema_cache import ExportSchemaCache
 
 
-def test_reuses_schema_for_unchanged_workspace_version():
-    clear_export_schema_cache()
-    fields = ["invoice_id", "amount"]
-    first = export_schema("ws-204", 7, fields)
-    second = export_schema("ws-204", 7, list(fields))
+def test_reuses_snapshot_for_unchanged_workspace_version():
+    cache = ExportSchemaCache()
+
+    first = cache.snapshot("ws-204", 7, ["invoice_id", "amount"])
+    second = cache.snapshot("ws-204", 7, ["invoice_id", "amount"])
+
+    assert second is first
+
+
+def test_replaces_snapshot_when_workspace_version_changes():
+    cache = ExportSchemaCache()
+
+    old = cache.snapshot("ws-204", 7, ["invoice_id", "amount"])
+    new = cache.snapshot("ws-204", 8, ["invoice_id", "amount", "currency"])
+
+    assert new is not old
+    assert new.fields == ("invoice_id", "amount", "currency")
+
+
+def test_clear_discards_current_snapshot():
+    cache = ExportSchemaCache()
+    first = cache.snapshot("ws-204", 7, ["invoice_id", "amount"])
+
+    cache.clear()
+
+    second = cache.snapshot("ws-204", 7, ["invoice_id", "amount"])
     assert second == first
+    assert second is not first

--- a/tests/test_export_schema_models.py
+++ b/tests/test_export_schema_models.py
@@ -1,0 +1,19 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.export_schema_models import SchemaSnapshot
+
+
+def test_snapshot_identity_includes_workspace_and_version():
+    first = SchemaSnapshot("ws-204", 7, ("invoice_id",))
+    second = SchemaSnapshot("ws-204", 8, ("invoice_id",))
+
+    assert first != second
+
+
+def test_snapshot_is_immutable():
+    snapshot = SchemaSnapshot("ws-204", 7, ("invoice_id",))
+
+    with pytest.raises(FrozenInstanceError):
+        snapshot.workspace_version = 8


### PR DESCRIPTION
## Summary

Replace the process-wide workspace-to-tuple map with `ExportSchemaCache`, which keeps one immutable `SchemaSnapshot` per workspace. A version change replaces the current entry.

## Scope

- snapshot model with workspace/version identity
- instance cache suitable for dependency injection
- same-version object reuse
- version-change replacement
- focused model/cache coverage and operational documentation

The standalone scheduler adapter is maintained in a separately deployed package and was not included in this refactor.