### PR TITLE
Refresh export schema cache by workspace revision

### DIFF
--- a/docs/export-schema-cache.md
+++ b/docs/export-schema-cache.md
@@ -1,0 +1,8 @@
+# Export schema cache
+
+The export helper accepts a workspace identifier, a numeric workspace version, and
+the configured field sequence. Callers receive an immutable tuple of field names.
+
+Entries are reused for an identical workspace/version pair. A changed version
+builds a separate entry. The module-level helper remains available to existing
+scheduler and invoice-export integrations.

--- a/src/export_schema_cache.py
+++ b/src/export_schema_cache.py
@@ -2,10 +2,11 @@ _schema_cache = {}
 
 
 def export_schema(workspace_id, workspace_version, fields):
-    if workspace_id in _schema_cache:
-        return _schema_cache[workspace_id]
+    cache_key = (workspace_id, workspace_version)
+    if cache_key in _schema_cache:
+        return _schema_cache[cache_key]
     schema = tuple(fields)
-    _schema_cache[workspace_id] = schema
+    _schema_cache[cache_key] = schema
     return schema
 
 

--- a/tests/test_export_schema_cache.py
+++ b/tests/test_export_schema_cache.py
@@ -7,3 +7,22 @@ def test_reuses_schema_for_unchanged_workspace_version():
     first = export_schema("ws-204", 7, fields)
     second = export_schema("ws-204", 7, list(fields))
     assert second == first
+
+
+def test_builds_new_schema_when_workspace_version_changes():
+    clear_export_schema_cache()
+
+    old = export_schema("ws-204", 7, ["invoice_id", "amount"])
+    new = export_schema("ws-204", 8, ["invoice_id", "amount", "currency"])
+
+    assert old == ("invoice_id", "amount")
+    assert new == ("invoice_id", "amount", "currency")
+
+
+def test_separates_workspaces_with_the_same_version():
+    clear_export_schema_cache()
+
+    first = export_schema("ws-204", 8, ["invoice_id", "currency"])
+    second = export_schema("ws-771", 8, ["invoice_id", "tax_code"])
+
+    assert first != second


### PR DESCRIPTION
The invoice export worker returned an earlier column set after workspace configuration changed. This branch includes the workspace version in the module cache key, adds coverage for an increasing version, and documents the existing helper contract.

The scheduler package continues to use the module-level function and tuple result.