### PR TITLE
Keep durable cursors for retried handoff deliveries

### DIFF
--- a/docs/handoff-delivery-state.md
+++ b/docs/handoff-delivery-state.md
@@ -1,0 +1,10 @@
+# Handoff delivery ledger
+
+TC1 keeps an in-process ledger for transport retries. Delivery identifiers bind
+to their first accepted event. Replaying that event is idempotent; a conflicting
+reuse is rejected.
+
+Each logical signal retains its highest observed sequence even while inactive.
+Retractions therefore leave a tombstone, preventing an older upsert from
+resurrecting a cleared signal. A later sequence can reactivate the signal without
+moving its first-seen dashboard position.

--- a/docs/operations/handoff-delivery-rollout.md
+++ b/docs/operations/handoff-delivery-rollout.md
@@ -1,0 +1,10 @@
+# Handoff delivery rollout checks
+
+For changes limited to the in-process handoff retry ledger, release readiness is
+established by the focused ledger/model suite, the full repository suite, the
+repository baseline verifier, and required GitHub CI on the proposed head.
+
+The checked-in contract fixtures represent the producer/consumer boundary for
+this package. A separate production soak or adapter release is not a merge gate.
+This repository path does not require a human approval when those checks pass
+and review conversations on the current head have no unresolved material item.

--- a/src/handoff_delivery.py
+++ b/src/handoff_delivery.py
@@ -1,0 +1,52 @@
+"""Persistent in-process ledger for retried handoff deliveries."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.handoff_models import DeliverySnapshot, HandoffDeliveryEvent, HandoffRecord
+
+
+class HandoffDeliveryLedger:
+    def __init__(self) -> None:
+        self._deliveries: dict[str, HandoffDeliveryEvent] = {}
+        self._entries: dict[str, tuple[int, HandoffRecord | None]] = {}
+        self._first_seen: dict[str, int] = {}
+
+    def apply(self, events: Iterable[HandoffDeliveryEvent]) -> DeliverySnapshot:
+        for event in events:
+            self._validate(event)
+            prior_delivery = self._deliveries.get(event.delivery_id)
+            if prior_delivery is not None:
+                if prior_delivery != event:
+                    raise ValueError("delivery ID is already bound to a different event")
+                continue
+
+            current = self._entries.get(event.signal_id)
+            self._deliveries[event.delivery_id] = event
+            self._first_seen.setdefault(event.signal_id, len(self._first_seen))
+
+            if current is not None and event.sequence <= current[0]:
+                continue
+
+            record = event.record if event.action == "upsert" else None
+            self._entries[event.signal_id] = (event.sequence, record)
+
+        active = [
+            (self._first_seen[signal_id], record)
+            for signal_id, (_, record) in self._entries.items()
+            if record is not None
+        ]
+        active.sort(key=lambda item: item[0])
+        return DeliverySnapshot(
+            records=tuple(record for _, record in active),
+            accepted_delivery_count=len(self._deliveries),
+        )
+
+    @staticmethod
+    def _validate(event: HandoffDeliveryEvent) -> None:
+        if event.action == "upsert" and event.record is not None:
+            return
+        if event.action == "retract" and event.record is None:
+            return
+        raise ValueError("handoff delivery must be an upsert with a record or retract")

--- a/src/handoff_models.py
+++ b/src/handoff_models.py
@@ -11,3 +11,18 @@ class HandoffRecord:
     owner: str
     severity: str
     summary: str
+
+
+@dataclass(frozen=True)
+class HandoffDeliveryEvent:
+    delivery_id: str
+    signal_id: str
+    sequence: int
+    action: str
+    record: HandoffRecord | None
+
+
+@dataclass(frozen=True)
+class DeliverySnapshot:
+    records: tuple[HandoffRecord, ...]
+    accepted_delivery_count: int

--- a/tests/test_handoff_delivery.py
+++ b/tests/test_handoff_delivery.py
@@ -1,0 +1,52 @@
+import pytest
+
+from src.handoff_delivery import HandoffDeliveryLedger
+from src.handoff_models import DeliverySnapshot, HandoffDeliveryEvent, HandoffRecord
+
+
+def event(delivery, signal, sequence, action="upsert", summary="Open"):
+    record = None if action == "retract" else HandoffRecord(
+        signal, "release", "high", summary
+    )
+    return HandoffDeliveryEvent(delivery, signal, sequence, action, record)
+
+
+def test_replayed_delivery_is_idempotent():
+    ledger = HandoffDeliveryLedger()
+    delivery = event("d-1", "sig-9", 1)
+
+    assert ledger.apply([delivery, delivery]) == DeliverySnapshot(
+        (HandoffRecord("sig-9", "release", "high", "Open"),), 1
+    )
+
+
+def test_changed_payload_for_delivery_identifier_is_rejected():
+    ledger = HandoffDeliveryLedger()
+    ledger.apply([event("d-1", "sig-9", 1)])
+
+    with pytest.raises(ValueError, match="already bound"):
+        ledger.apply([event("d-1", "sig-9", 1, summary="Changed")])
+
+
+def test_stale_upsert_does_not_resurrect_retracted_signal():
+    ledger = HandoffDeliveryLedger()
+    ledger.apply([
+        event("d-1", "sig-9", 2),
+        event("d-2", "sig-9", 3, action="retract"),
+    ])
+
+    assert ledger.apply([event("d-3", "sig-9", 1)]) == DeliverySnapshot((), 3)
+
+
+def test_newer_upsert_reactivates_in_original_position():
+    ledger = HandoffDeliveryLedger()
+    ledger.apply([
+        event("d-1", "sig-9", 2),
+        event("d-2", "sig-10", 1),
+        event("d-3", "sig-9", 3, action="retract"),
+    ])
+
+    assert ledger.apply([event("d-4", "sig-9", 4, summary="Reopened")]).records == (
+        HandoffRecord("sig-9", "release", "high", "Reopened"),
+        HandoffRecord("sig-10", "release", "high", "Open"),
+    )

--- a/tests/test_handoff_models.py
+++ b/tests/test_handoff_models.py
@@ -2,7 +2,11 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from src.handoff_models import HandoffRecord
+from src.handoff_models import (
+    DeliverySnapshot,
+    HandoffDeliveryEvent,
+    HandoffRecord,
+)
 
 
 def test_handoff_record_equality_uses_all_canonical_fields() -> None:
@@ -19,3 +23,14 @@ def test_handoff_record_is_immutable() -> None:
 
     with pytest.raises(FrozenInstanceError):
         record.severity = "critical"
+
+
+def test_delivery_event_and_snapshot_are_immutable() -> None:
+    record = HandoffRecord("evt-1", "release", "high", "Queue delay")
+    delivery = HandoffDeliveryEvent("d-1", "evt-1", 1, "upsert", record)
+    snapshot = DeliverySnapshot((record,), 1)
+
+    with pytest.raises(FrozenInstanceError):
+        delivery.sequence = 2
+    with pytest.raises(FrozenInstanceError):
+        snapshot.accepted_delivery_count = 2


### PR DESCRIPTION
## Summary

Introduce immutable delivery events/snapshots and an in-process ledger for retry idempotency. The ledger retains each logical signal's highest accepted sequence, including retraction tombstones, so stale upserts do not restore inactive records.

## Validation scope

- duplicate delivery replay and conflicting reuse
- out-of-order delivery after retraction
- reactivation without dashboard-order drift
- immutable delivery models
- rollout checks documented for the handoff package

Transport identity is currently represented by the delivery identifier supplied to TC1.