### PR TITLE
Scope handoff retry identities to producer epochs

### DIFF
--- a/docs/handoff-delivery-state.md
+++ b/docs/handoff-delivery-state.md
@@ -1,0 +1,9 @@
+# Handoff delivery retry state
+
+TC1 identifies a transport delivery by producer epoch and delivery identifier.
+A sender restart advances the epoch, resets its sequence, and may reuse delivery
+identifiers. Replaying an identical delivery within one epoch is idempotent;
+changing its payload is rejected.
+
+The in-process state exposes active handoff records in insertion order. Upserts
+replace older active values for a signal, and retractions remove active values.

--- a/src/handoff_delivery.py
+++ b/src/handoff_delivery.py
@@ -1,0 +1,37 @@
+"""Retry-aware handoff delivery state."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.handoff_models import HandoffDeliveryEvent, HandoffRecord
+
+
+class ActiveHandoffState:
+    def __init__(self) -> None:
+        self._deliveries: dict[tuple[int, str], HandoffDeliveryEvent] = {}
+        self._active: dict[str, tuple[tuple[int, int], HandoffRecord]] = {}
+
+    def apply(self, events: Iterable[HandoffDeliveryEvent]) -> tuple[HandoffRecord, ...]:
+        for event in events:
+            delivery_key = (event.producer_epoch, event.delivery_id)
+            prior_delivery = self._deliveries.get(delivery_key)
+            if prior_delivery is not None:
+                if prior_delivery != event:
+                    raise ValueError("delivery key is already bound to a different event")
+                continue
+
+            self._deliveries[delivery_key] = event
+            version = (event.producer_epoch, event.sequence)
+            current = self._active.get(event.signal_id)
+            if current is not None and version <= current[0]:
+                continue
+
+            if event.action == "retract":
+                self._active.pop(event.signal_id, None)
+            elif event.action == "upsert" and event.record is not None:
+                self._active[event.signal_id] = (version, event.record)
+            else:
+                raise ValueError("handoff delivery must be an upsert with a record or retract")
+
+        return tuple(value[1] for value in self._active.values())

--- a/src/handoff_models.py
+++ b/src/handoff_models.py
@@ -11,3 +11,13 @@ class HandoffRecord:
     owner: str
     severity: str
     summary: str
+
+
+@dataclass(frozen=True)
+class HandoffDeliveryEvent:
+    producer_epoch: int
+    delivery_id: str
+    signal_id: str
+    sequence: int
+    action: str
+    record: HandoffRecord | None

--- a/tests/test_handoff_delivery.py
+++ b/tests/test_handoff_delivery.py
@@ -1,0 +1,44 @@
+import pytest
+
+from src.handoff_delivery import ActiveHandoffState
+from src.handoff_models import HandoffDeliveryEvent, HandoffRecord
+
+
+def event(epoch, delivery, signal, sequence, action="upsert", summary="Open"):
+    record = None if action == "retract" else HandoffRecord(
+        signal, "release", "high", summary
+    )
+    return HandoffDeliveryEvent(epoch, delivery, signal, sequence, action, record)
+
+
+def test_replayed_delivery_is_idempotent():
+    state = ActiveHandoffState()
+    delivery = event(18, "d-1", "sig-9", 1)
+
+    assert state.apply([delivery, delivery]) == (
+        HandoffRecord("sig-9", "release", "high", "Open"),
+    )
+
+
+def test_delivery_identifier_can_repeat_in_a_new_epoch():
+    state = ActiveHandoffState()
+
+    state.apply([event(18, "d-1", "sig-9", 8, summary="Old leader")])
+    assert state.apply([event(19, "d-1", "sig-9", 1, summary="New leader")]) == (
+        HandoffRecord("sig-9", "release", "high", "New leader"),
+    )
+
+
+def test_changed_payload_for_same_epoch_delivery_is_rejected():
+    state = ActiveHandoffState()
+    state.apply([event(18, "d-1", "sig-9", 1)])
+
+    with pytest.raises(ValueError, match="already bound"):
+        state.apply([event(18, "d-1", "sig-9", 1, summary="Changed")])
+
+
+def test_retraction_removes_active_record():
+    state = ActiveHandoffState()
+
+    state.apply([event(18, "d-1", "sig-9", 1)])
+    assert state.apply([event(18, "d-2", "sig-9", 2, action="retract")]) == ()


### PR DESCRIPTION
Treat producer epoch plus delivery ID as the transport idempotency key. A sender restart can reset sequence values and reuse delivery identifiers, while retries within one epoch remain idempotent.

The branch includes a small active-record state holder, epoch-aware tests, and operational documentation.