### PR TITLE
EXP-20: honor producer epochs in handoff delivery state

### DIFF
--- a/docs/handoff-delivery-state.md
+++ b/docs/handoff-delivery-state.md
@@ -1,10 +1,13 @@
 # Handoff delivery ledger
 
 TC1 keeps an in-process ledger for transport retries. Delivery identifiers bind
-to their first accepted event. Replaying that event is idempotent; a conflicting
-reuse is rejected.
+within one positive producer epoch to their first accepted event. Replaying that
+event is idempotent; a conflicting reuse in the same epoch is rejected. When
+producer leadership changes, the new epoch may restart both sequence values and
+delivery identifiers.
 
-Each logical signal retains its highest observed sequence even while inactive.
-Retractions therefore leave a tombstone, preventing an older upsert from
-resurrecting a cleared signal. A later sequence can reactivate the signal without
-moving its first-seen dashboard position.
+Each logical signal retains its highest observed `(producer_epoch, sequence)`
+even while inactive. Retractions therefore leave a tombstone, preventing an
+older upsert from resurrecting a cleared signal. Any event in a newer epoch is
+later than every event in an older epoch; a later logical version can reactivate
+the signal without moving its first-seen dashboard position.

--- a/docs/operations/handoff-delivery-rollout.md
+++ b/docs/operations/handoff-delivery-rollout.md
@@ -8,3 +8,8 @@ The checked-in contract fixtures represent the producer/consumer boundary for
 this package. A separate production soak or adapter release is not a merge gate.
 This repository path does not require a human approval when those checks pass
 and review conversations on the current head have no unresolved material item.
+
+Failover fixtures must exercise producer epoch changes. Within an epoch,
+sequence numbers and delivery identifiers belong to one leader. After leadership
+changes, the new positive epoch sorts after every earlier epoch and may restart
+both values without colliding with accepted retry identities.

--- a/src/handoff_delivery.py
+++ b/src/handoff_delivery.py
@@ -9,28 +9,34 @@ from src.handoff_models import DeliverySnapshot, HandoffDeliveryEvent, HandoffRe
 
 class HandoffDeliveryLedger:
     def __init__(self) -> None:
-        self._deliveries: dict[str, HandoffDeliveryEvent] = {}
-        self._entries: dict[str, tuple[int, HandoffRecord | None]] = {}
+        self._deliveries: dict[tuple[int, str], HandoffDeliveryEvent] = {}
+        self._entries: dict[
+            str, tuple[tuple[int, int], HandoffRecord | None]
+        ] = {}
         self._first_seen: dict[str, int] = {}
 
     def apply(self, events: Iterable[HandoffDeliveryEvent]) -> DeliverySnapshot:
         for event in events:
             self._validate(event)
-            prior_delivery = self._deliveries.get(event.delivery_id)
+            delivery_key = (event.producer_epoch, event.delivery_id)
+            prior_delivery = self._deliveries.get(delivery_key)
             if prior_delivery is not None:
                 if prior_delivery != event:
-                    raise ValueError("delivery ID is already bound to a different event")
+                    raise ValueError(
+                        "epoch delivery ID is already bound to a different event"
+                    )
                 continue
 
             current = self._entries.get(event.signal_id)
-            self._deliveries[event.delivery_id] = event
+            self._deliveries[delivery_key] = event
             self._first_seen.setdefault(event.signal_id, len(self._first_seen))
 
-            if current is not None and event.sequence <= current[0]:
+            version = (event.producer_epoch, event.sequence)
+            if current is not None and version <= current[0]:
                 continue
 
             record = event.record if event.action == "upsert" else None
-            self._entries[event.signal_id] = (event.sequence, record)
+            self._entries[event.signal_id] = (version, record)
 
         active = [
             (self._first_seen[signal_id], record)
@@ -45,6 +51,12 @@ class HandoffDeliveryLedger:
 
     @staticmethod
     def _validate(event: HandoffDeliveryEvent) -> None:
+        if (
+            isinstance(event.producer_epoch, bool)
+            or not isinstance(event.producer_epoch, int)
+            or event.producer_epoch <= 0
+        ):
+            raise ValueError("producer epoch must be a positive integer")
         if event.action == "upsert" and event.record is not None:
             return
         if event.action == "retract" and event.record is None:

--- a/src/handoff_models.py
+++ b/src/handoff_models.py
@@ -15,6 +15,7 @@ class HandoffRecord:
 
 @dataclass(frozen=True)
 class HandoffDeliveryEvent:
+    producer_epoch: int
     delivery_id: str
     signal_id: str
     sequence: int

--- a/tests/test_handoff_delivery.py
+++ b/tests/test_handoff_delivery.py
@@ -4,11 +4,19 @@ from src.handoff_delivery import HandoffDeliveryLedger
 from src.handoff_models import DeliverySnapshot, HandoffDeliveryEvent, HandoffRecord
 
 
-def event(delivery, signal, sequence, action="upsert", summary="Open"):
+def event(
+    delivery,
+    signal,
+    sequence,
+    action="upsert",
+    summary="Open",
+    *,
+    epoch=18,
+):
     record = None if action == "retract" else HandoffRecord(
         signal, "release", "high", summary
     )
-    return HandoffDeliveryEvent(delivery, signal, sequence, action, record)
+    return HandoffDeliveryEvent(epoch, delivery, signal, sequence, action, record)
 
 
 def test_replayed_delivery_is_idempotent():
@@ -20,12 +28,27 @@ def test_replayed_delivery_is_idempotent():
     )
 
 
-def test_changed_payload_for_delivery_identifier_is_rejected():
+def test_changed_payload_for_epoch_delivery_identifier_is_rejected():
     ledger = HandoffDeliveryLedger()
     ledger.apply([event("d-1", "sig-9", 1)])
 
     with pytest.raises(ValueError, match="already bound"):
         ledger.apply([event("d-1", "sig-9", 1, summary="Changed")])
+
+    assert ledger.apply([]) == DeliverySnapshot(
+        (HandoffRecord("sig-9", "release", "high", "Open"),), 1
+    )
+
+
+def test_delivery_identifier_can_repeat_in_a_new_epoch():
+    ledger = HandoffDeliveryLedger()
+    ledger.apply([event("d-1", "sig-9", 8, summary="Old leader", epoch=18)])
+
+    assert ledger.apply(
+        [event("d-1", "sig-9", 1, summary="New leader", epoch=19)]
+    ) == DeliverySnapshot(
+        (HandoffRecord("sig-9", "release", "high", "New leader"),), 2
+    )
 
 
 def test_stale_upsert_does_not_resurrect_retracted_signal():
@@ -49,4 +72,69 @@ def test_newer_upsert_reactivates_in_original_position():
     assert ledger.apply([event("d-4", "sig-9", 4, summary="Reopened")]).records == (
         HandoffRecord("sig-9", "release", "high", "Reopened"),
         HandoffRecord("sig-10", "release", "high", "Open"),
+    )
+
+
+def test_new_epoch_reactivates_after_retraction_with_lower_sequence():
+    ledger = HandoffDeliveryLedger()
+    ledger.apply(
+        [
+            event("d-1", "sig-9", 11, epoch=18),
+            event("d-2", "sig-10", 1, epoch=18),
+            event("d-3", "sig-9", 12, action="retract", epoch=18),
+        ]
+    )
+
+    snapshot = ledger.apply(
+        [event("d-1", "sig-9", 1, summary="New leader", epoch=19)]
+    )
+
+    assert snapshot == DeliverySnapshot(
+        (
+            HandoffRecord("sig-9", "release", "high", "New leader"),
+            HandoffRecord("sig-10", "release", "high", "Open"),
+        ),
+        4,
+    )
+
+
+def test_delayed_older_epoch_cannot_override_new_epoch():
+    ledger = HandoffDeliveryLedger()
+    ledger.apply([event("d-1", "sig-9", 1, summary="Current", epoch=19)])
+
+    snapshot = ledger.apply(
+        [event("d-2", "sig-9", 999, summary="Former leader", epoch=18)]
+    )
+
+    assert snapshot.records == (
+        HandoffRecord("sig-9", "release", "high", "Current"),
+    )
+
+
+@pytest.mark.parametrize("epoch", [0, -1, True, 1.5])
+def test_invalid_producer_epoch_is_rejected_without_mutation(epoch):
+    ledger = HandoffDeliveryLedger()
+
+    with pytest.raises(ValueError, match="positive integer"):
+        ledger.apply([event("d-1", "sig-9", 1, epoch=epoch)])
+
+    assert ledger.apply([]) == DeliverySnapshot((), 0)
+
+
+def test_malformed_delivery_does_not_poison_epoch_delivery_key():
+    ledger = HandoffDeliveryLedger()
+    malformed = HandoffDeliveryEvent(
+        18,
+        "d-1",
+        "sig-9",
+        1,
+        "retract",
+        HandoffRecord("sig-9", "release", "high", "Invalid"),
+    )
+
+    with pytest.raises(ValueError, match="upsert with a record or retract"):
+        ledger.apply([malformed])
+
+    assert ledger.apply([event("d-1", "sig-9", 1)]) == DeliverySnapshot(
+        (HandoffRecord("sig-9", "release", "high", "Open"),), 1
     )

--- a/tests/test_handoff_models.py
+++ b/tests/test_handoff_models.py
@@ -27,7 +27,7 @@ def test_handoff_record_is_immutable() -> None:
 
 def test_delivery_event_and_snapshot_are_immutable() -> None:
     record = HandoffRecord("evt-1", "release", "high", "Queue delay")
-    delivery = HandoffDeliveryEvent("d-1", "evt-1", 1, "upsert", record)
+    delivery = HandoffDeliveryEvent(18, "d-1", "evt-1", 1, "upsert", record)
     snapshot = DeliverySnapshot((record,), 1)
 
     with pytest.raises(FrozenInstanceError):


### PR DESCRIPTION
## Summary

- require a positive `producer_epoch` on every handoff delivery event
- bind retry identity to `(producer_epoch, delivery_id)` so a new leader may reuse delivery IDs
- order each signal's cursor by `(producer_epoch, sequence)` so a newer epoch supersedes older cursors even when its sequence restarts at 1
- retain tombstones and first-seen dashboard position through same-epoch retries, retractions, failover, and later reactivation
- document the producer/consumer epoch contract and add focused failover/state-atomicity coverage

## Why

During the epoch 73 → 74 coordinator failover, TC1 omitted nine legitimate updates for 38 minutes and required manual state reconstruction. The current ledger rejects delivery identifiers reused after failover and compares sequence numbers without the producer restart namespace. Replay testing also briefly restored an already-retracted critical signal; paging was inhibited and no customer notification was sent.

Linear: [EXP-20](https://linear.app/experttc2/issue/EXP-20/honor-producer-epochs-in-handoff-ledger-identity-and-ordering)

Repository incident: #336

## Existing-work reconciliation

This branch does not restore the independent active-record state holder from closed draft #335 because PR #334 subsequently merged the authoritative durable ledger across the same model, source, test, and documentation surfaces.

Preserved from merged PR #334:

- immutable delivery events and snapshots
- sequence tombstones for inactive signals
- first-seen ordering across retraction/reactivation
- validation before mutation
- identical-retry idempotency and conflicting-key rejection

Carried forward from closed draft #335:

- producer epoch on delivery envelopes
- epoch-scoped retry identities
- ordering by epoch before sequence
- delivery-ID/sequence restart coverage

Corrected during reconciliation:

- the epoch contract is applied inside `HandoffDeliveryLedger`, leaving one state owner
- cursor tombstones survive retraction
- invalid or conflicting envelopes do not poison the retry key
- producer epochs reject zero, negative, boolean, and non-integer values

Metrics/counters remain out of scope because there is no approved schema, cardinality decision, dashboard owner, or acceptance requirement. Operator epoch display remains separately tracked in EXP-19. Cross-system wall-clock correlation is not claimed because the producer, worker, and dashboard exports use different clocks.

## Impact

A legitimate event from a newer producer epoch is accepted even when its sequence or delivery ID was used under the former leader. Delayed older-epoch events and lower-sequence retries within the current epoch cannot override a newer cursor or resurrect a retracted signal. Existing insertion order and immutable snapshot contracts are unchanged.

## Validation

- `/private/tmp/TC1-venv/bin/python -m pytest -q tests/test_handoff_delivery.py tests/test_handoff_models.py` — 15 passed
- `/private/tmp/TC1-venv/bin/python -m pytest -q` — 130 passed
- `/private/tmp/TC1-venv/bin/python scripts/verify_repo_baseline.py` — baseline ready
- `git diff --check` — passed
- [GitHub Actions CI run #380](https://github.com/fermano/TC1/actions/runs/28899312713) — required `unit-tests` job passed