### PR TITLE
EXP-21: preserve zero retry budget after policy reload

### DIFF
--- a/src/workspace_policy.py
+++ b/src/workspace_policy.py
@@ -1,0 +1,13 @@
+"""Workspace-policy reload helpers for queue handoffs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def retry_budget_from_record(record: Mapping[str, object], default: int) -> int:
+    """Restore an explicit retry override from a persisted workspace record."""
+    requested = record.get("retry_budget")
+    if requested is None:
+        return default
+    return int(requested)

--- a/tests/test_workspace_policy.py
+++ b/tests/test_workspace_policy.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.workspace_policy import retry_budget_from_record
+
+
+@pytest.mark.parametrize("record", ({}, {"retry_budget": None}))
+def test_missing_retry_budget_inherits_workspace_default(record):
+    assert retry_budget_from_record(record, default=3) == 3
+
+
+def test_explicit_zero_retry_budget_survives_policy_reload():
+    assert retry_budget_from_record({"retry_budget": 0}, default=3) == 0
+
+
+def test_positive_retry_budget_survives_policy_reload():
+    assert retry_budget_from_record({"retry_budget": 2}, default=3) == 2


### PR DESCRIPTION
## Summary

- carry forward the persisted workspace-policy loader from #201 onto current `main`
- preserve explicit retry overrides, including `0`
- inherit the workspace default only when `retry_budget` is omitted or null
- add focused regression coverage for the persisted reload boundary

Linear: [EXP-21](https://linear.app/experttc2/issue/EXP-21/preserve-explicit-zero-retry-budgets-after-workspace-policy-reload)
Closes #302
Existing implementation reconciled: #201

## Why

Workflow Support case WF-9921 reports that `ws-6b9` set `retry_budget=0` to prevent duplicate third-party charges. Direct intake already preserves zero, but the persisted worker reload path converts zero to an absent value and the queue assembler applies its default of three, producing four sandbox charge attempts and blocking production enablement.

The earlier #201 implementation had the correct bounded loader semantics, but it was based on an obsolete `main` and explicitly lacked a loader regression. This PR preserves that implementation on current `main` and adds the missing focused coverage rather than replacing the design.

## Scope

This changes only the persisted workspace-policy reload helper and its tests. It does not modify direct intake, webhook replay batch limits, or retry execution mechanics.

## Validation

- `/private/tmp/TC1-venv/bin/python -m pytest -q tests/test_workspace_policy.py` — 4 passed
- `/private/tmp/TC1-venv/bin/python -m pytest -q` — 134 passed
- `/private/tmp/TC1-venv/bin/python scripts/verify_repo_baseline.py` — passed
- `git diff --check main...HEAD` — passed
