### PR TITLE
Apply persisted checkpoint batches atomically

### DIFF
--- a/docs/operations/release-checkpoint-rollout.md
+++ b/docs/operations/release-checkpoint-rollout.md
@@ -1,0 +1,9 @@
+# Release checkpoint rollout
+
+Changes to checkpoint persistence require focused store/model tests, the full
+repository suite, repository baseline verification, diff checks, and required
+GitHub CI on the proposed head.
+
+Migration and mixed-version fixtures in the repository define the supported
+storage boundary. When those fixtures and required checks pass, this TC1 path
+does not require a separate production soak or approving review before merge.

--- a/docs/release-checkpoint-store.md
+++ b/docs/release-checkpoint-store.md
@@ -1,0 +1,10 @@
+# Release checkpoint store
+
+TC1 persists release-stream checkpoints in `checkpoint_state`. A checkpoint is
+ordered by generation and then offset, allowing a new generation to start again
+at a smaller offset.
+
+Updates are applied as an atomic batch under an immediate SQLite transaction.
+Batch identifiers bind to the canonical ordered update payload. An identical
+retry returns its recorded result; conflicting reuse fails without modifying
+checkpoint state.

--- a/src/checkpoint_models.py
+++ b/src/checkpoint_models.py
@@ -1,0 +1,18 @@
+"""Immutable release-checkpoint values and batch results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    stream_id: str
+    generation: int
+    offset: int
+
+
+@dataclass(frozen=True)
+class CheckpointBatchResult:
+    batch_id: str
+    checkpoints: tuple[Checkpoint, ...]

--- a/src/release_checkpoint_store.py
+++ b/src/release_checkpoint_store.py
@@ -1,0 +1,131 @@
+"""Transactional persisted release checkpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Iterable
+
+from src.checkpoint_models import Checkpoint, CheckpointBatchResult
+
+
+class ReleaseCheckpointStore:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+
+    def initialize(self) -> None:
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS checkpoint_state "
+            "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+        )
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS applied_checkpoint_batches "
+            "(batch_id TEXT PRIMARY KEY, payload_digest TEXT NOT NULL, result_json TEXT NOT NULL)"
+        )
+        self.connection.commit()
+
+    def apply_batch(
+        self,
+        batch_id: str,
+        updates: Iterable[Checkpoint],
+    ) -> CheckpointBatchResult:
+        update_list = tuple(updates)
+        self._validate(batch_id, update_list)
+        payload = json.dumps(
+            [
+                {
+                    "stream_id": update.stream_id,
+                    "generation": update.generation,
+                    "offset": update.offset,
+                }
+                for update in update_list
+            ],
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+        self.connection.execute("BEGIN IMMEDIATE")
+        try:
+            prior = self.connection.execute(
+                "SELECT payload_digest, result_json FROM applied_checkpoint_batches "
+                "WHERE batch_id=?",
+                (batch_id,),
+            ).fetchone()
+            if prior is not None:
+                if prior[0] != digest:
+                    raise ValueError("checkpoint batch ID is already bound to another payload")
+                result = self._decode_result(batch_id, prior[1])
+                self.connection.commit()
+                return result
+
+            applied: list[Checkpoint] = []
+            for update in update_list:
+                row = self.connection.execute(
+                    "SELECT generation, offset FROM checkpoint_state WHERE stream_id=?",
+                    (update.stream_id,),
+                ).fetchone()
+                if row is None or (update.generation, update.offset) > (row[0], row[1]):
+                    self.connection.execute(
+                        "INSERT INTO checkpoint_state VALUES (?, ?, ?) "
+                        "ON CONFLICT(stream_id) DO UPDATE SET "
+                        "generation=excluded.generation, offset=excluded.offset",
+                        (update.stream_id, update.generation, update.offset),
+                    )
+                    current = update
+                else:
+                    current = Checkpoint(update.stream_id, row[0], row[1])
+                applied.append(current)
+
+            result_json = json.dumps(
+                [
+                    {
+                        "stream_id": checkpoint.stream_id,
+                        "generation": checkpoint.generation,
+                        "offset": checkpoint.offset,
+                    }
+                    for checkpoint in applied
+                ],
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            self.connection.execute(
+                "INSERT INTO applied_checkpoint_batches VALUES (?, ?, ?)",
+                (batch_id, digest, result_json),
+            )
+            self.connection.commit()
+            return CheckpointBatchResult(batch_id, tuple(applied))
+        except BaseException:
+            self.connection.rollback()
+            raise
+
+    def read(self, stream_id: str) -> Checkpoint | None:
+        row = self.connection.execute(
+            "SELECT stream_id, generation, offset FROM checkpoint_state WHERE stream_id=?",
+            (stream_id,),
+        ).fetchone()
+        return Checkpoint(*row) if row is not None else None
+
+    @staticmethod
+    def _validate(batch_id: str, updates: tuple[Checkpoint, ...]) -> None:
+        if not batch_id.strip():
+            raise ValueError("checkpoint batch ID must not be blank")
+        stream_ids = [update.stream_id for update in updates]
+        if any(not stream_id.strip() for stream_id in stream_ids):
+            raise ValueError("checkpoint stream ID must not be blank")
+        if len(stream_ids) != len(set(stream_ids)):
+            raise ValueError("checkpoint batch contains duplicate streams")
+        if any(update.generation < 0 or update.offset < 0 for update in updates):
+            raise ValueError("checkpoint generation and offset must be non-negative")
+
+    @staticmethod
+    def _decode_result(batch_id: str, value: str) -> CheckpointBatchResult:
+        rows = json.loads(value)
+        return CheckpointBatchResult(
+            batch_id,
+            tuple(
+                Checkpoint(row["stream_id"], row["generation"], row["offset"])
+                for row in rows
+            ),
+        )

--- a/tests/test_checkpoint_models.py
+++ b/tests/test_checkpoint_models.py
@@ -1,0 +1,15 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.checkpoint_models import Checkpoint, CheckpointBatchResult
+
+
+def test_checkpoint_and_result_are_immutable():
+    checkpoint = Checkpoint("billing", 4, 91)
+    result = CheckpointBatchResult("batch-1", (checkpoint,))
+
+    with pytest.raises(FrozenInstanceError):
+        checkpoint.offset = 92
+    with pytest.raises(FrozenInstanceError):
+        result.batch_id = "batch-2"

--- a/tests/test_release_checkpoint_store.py
+++ b/tests/test_release_checkpoint_store.py
@@ -1,0 +1,77 @@
+import sqlite3
+
+import pytest
+
+from src.checkpoint_models import Checkpoint, CheckpointBatchResult
+from src.release_checkpoint_store import ReleaseCheckpointStore
+
+
+def store():
+    connection = sqlite3.connect(":memory:")
+    value = ReleaseCheckpointStore(connection)
+    value.initialize()
+    return value
+
+
+def test_batch_applies_all_checkpoint_updates():
+    value = store()
+
+    result = value.apply_batch(
+        "batch-1",
+        [Checkpoint("billing", 4, 91), Checkpoint("notifications", 2, 8)],
+    )
+
+    assert result == CheckpointBatchResult(
+        "batch-1",
+        (Checkpoint("billing", 4, 91), Checkpoint("notifications", 2, 8)),
+    )
+
+
+def test_identical_batch_retry_returns_original_result():
+    value = store()
+    updates = [Checkpoint("billing", 4, 91)]
+
+    first = value.apply_batch("batch-1", updates)
+    second = value.apply_batch("batch-1", list(updates))
+
+    assert second == first
+
+
+def test_changed_payload_for_batch_id_is_rejected_without_rebinding():
+    value = store()
+    original = [Checkpoint("billing", 4, 91)]
+    value.apply_batch("batch-1", original)
+
+    with pytest.raises(ValueError, match="already bound"):
+        value.apply_batch("batch-1", [Checkpoint("billing", 4, 92)])
+
+    assert value.apply_batch("batch-1", original).checkpoints == tuple(original)
+
+
+def test_new_generation_supersedes_higher_old_generation_offset():
+    value = store()
+    value.apply_batch("batch-1", [Checkpoint("billing", 4, 91)])
+
+    value.apply_batch("batch-2", [Checkpoint("billing", 5, 2)])
+
+    assert value.read("billing") == Checkpoint("billing", 5, 2)
+
+
+def test_failed_second_write_rolls_back_first_write_and_batch_binding():
+    connection = sqlite3.connect(":memory:")
+    value = ReleaseCheckpointStore(connection)
+    value.initialize()
+    connection.execute(
+        "CREATE TRIGGER reject_notifications BEFORE INSERT ON checkpoint_state "
+        "WHEN NEW.stream_id='notifications' BEGIN SELECT RAISE(ABORT, 'blocked'); END"
+    )
+    connection.commit()
+    updates = [Checkpoint("billing", 4, 91), Checkpoint("notifications", 2, 8)]
+
+    with pytest.raises(sqlite3.IntegrityError, match="blocked"):
+        value.apply_batch("batch-1", updates)
+
+    assert value.read("billing") is None
+    connection.execute("DROP TRIGGER reject_notifications")
+    connection.commit()
+    assert value.apply_batch("batch-1", updates).checkpoints == tuple(updates)


### PR DESCRIPTION
Introduce an immutable checkpoint model and SQLite-backed v2 store. Checkpoint batches are applied under an immediate transaction, bind their identifiers to canonical payloads, and record retry results.

The implementation creates `checkpoint_state` and `applied_checkpoint_batches`. Legacy checkpoint-table migration is expected to be handled by the rollout owner.