### PR TITLE
Dual-write release checkpoints during rolling deployment

### DIFF
--- a/docs/release-checkpoint-store.md
+++ b/docs/release-checkpoint-store.md
@@ -1,0 +1,8 @@
+# Release checkpoint persistence
+
+During a rolling deployment, TC1 keeps the legacy `checkpoints` table and the
+current `checkpoint_state` table. New writes are copied to both tables so
+workers on the older package can resume from the latest generation and offset.
+
+Current readers prefer the new table and fall back to legacy state when migration
+has not populated it yet.

--- a/src/checkpoint_models.py
+++ b/src/checkpoint_models.py
@@ -1,0 +1,12 @@
+"""Persisted release-stream checkpoint values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    stream_id: str
+    generation: int
+    offset: int

--- a/src/release_checkpoint_store.py
+++ b/src/release_checkpoint_store.py
@@ -1,0 +1,57 @@
+"""Rolling-compatible persisted release checkpoints."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from src.checkpoint_models import Checkpoint
+
+
+class ReleaseCheckpointStore:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+
+    def initialize(self) -> None:
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS checkpoints "
+            "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+        )
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS checkpoint_state "
+            "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+        )
+        self.connection.commit()
+
+    def write(self, checkpoint: Checkpoint) -> Checkpoint:
+        self.connection.execute(
+            "INSERT INTO checkpoint_state(stream_id, generation, offset) VALUES (?, ?, ?) "
+            "ON CONFLICT(stream_id) DO UPDATE SET generation=excluded.generation, offset=excluded.offset",
+            (checkpoint.stream_id, checkpoint.generation, checkpoint.offset),
+        )
+        self.connection.commit()
+        self.connection.execute(
+            "INSERT INTO checkpoints(stream_id, generation, offset) VALUES (?, ?, ?) "
+            "ON CONFLICT(stream_id) DO UPDATE SET generation=excluded.generation, offset=excluded.offset",
+            (checkpoint.stream_id, checkpoint.generation, checkpoint.offset),
+        )
+        self.connection.commit()
+        return checkpoint
+
+    def read(self, stream_id: str) -> Checkpoint | None:
+        row = self.connection.execute(
+            "SELECT stream_id, generation, offset FROM checkpoint_state WHERE stream_id=?",
+            (stream_id,),
+        ).fetchone()
+        if row is None:
+            row = self.connection.execute(
+                "SELECT stream_id, generation, offset FROM checkpoints WHERE stream_id=?",
+                (stream_id,),
+            ).fetchone()
+        return Checkpoint(*row) if row is not None else None
+
+    def read_legacy(self, stream_id: str) -> Checkpoint | None:
+        row = self.connection.execute(
+            "SELECT stream_id, generation, offset FROM checkpoints WHERE stream_id=?",
+            (stream_id,),
+        ).fetchone()
+        return Checkpoint(*row) if row is not None else None

--- a/tests/test_release_checkpoint_store.py
+++ b/tests/test_release_checkpoint_store.py
@@ -1,0 +1,38 @@
+import sqlite3
+
+from src.checkpoint_models import Checkpoint
+from src.release_checkpoint_store import ReleaseCheckpointStore
+
+
+def test_reads_legacy_checkpoint_after_initialization():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE checkpoints "
+        "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+    )
+    connection.execute("INSERT INTO checkpoints VALUES ('billing', 4, 91)")
+    store = ReleaseCheckpointStore(connection)
+
+    store.initialize()
+
+    assert store.read("billing") == Checkpoint("billing", 4, 91)
+
+
+def test_new_write_remains_visible_to_legacy_reader():
+    connection = sqlite3.connect(":memory:")
+    store = ReleaseCheckpointStore(connection)
+    store.initialize()
+
+    store.write(Checkpoint("billing", 5, 2))
+
+    assert store.read_legacy("billing") == Checkpoint("billing", 5, 2)
+
+
+def test_current_reader_prefers_current_table():
+    connection = sqlite3.connect(":memory:")
+    store = ReleaseCheckpointStore(connection)
+    store.initialize()
+    connection.execute("INSERT INTO checkpoints VALUES ('billing', 4, 91)")
+    connection.execute("INSERT INTO checkpoint_state VALUES ('billing', 5, 2)")
+
+    assert store.read("billing") == Checkpoint("billing", 5, 2)


### PR DESCRIPTION
Keep the legacy `checkpoints` table readable while new workers use `checkpoint_state`. New writes are copied to both layouts, and current readers can fall back to legacy rows.

This draft focuses on mixed-version visibility and does not yet model multi-stream batch identity.