### PR TITLE
Add upgrade and rollback for release checkpoints

### DIFF
--- a/docs/release-checkpoint-store.md
+++ b/docs/release-checkpoint-store.md
@@ -1,0 +1,8 @@
+# Release checkpoint migration
+
+The checkpoint schema may be upgraded from the legacy `checkpoints` table to
+`checkpoint_state`. Rollback copies current values back to the legacy table
+before removing the new table. A later upgrade repeats the copy.
+
+This permits the release package to return to the previous storage layout during
+the rollback window.

--- a/src/checkpoint_models.py
+++ b/src/checkpoint_models.py
@@ -1,0 +1,12 @@
+"""Persisted release-stream checkpoint values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    stream_id: str
+    generation: int
+    offset: int

--- a/src/release_checkpoint_store.py
+++ b/src/release_checkpoint_store.py
@@ -1,0 +1,71 @@
+"""Upgrade and rollback helpers for persisted release checkpoints."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from src.checkpoint_models import Checkpoint
+
+
+class CheckpointMigration:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+
+    def initialize_legacy(self) -> None:
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS checkpoints "
+            "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+        )
+        self.connection.commit()
+
+    def upgrade(self) -> None:
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS checkpoint_state "
+            "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+        )
+        rows = self.connection.execute(
+            "SELECT stream_id, generation, offset FROM checkpoints ORDER BY stream_id"
+        ).fetchall()
+        for row in rows:
+            self.connection.execute(
+                "INSERT INTO checkpoint_state VALUES (?, ?, ?) "
+                "ON CONFLICT(stream_id) DO UPDATE SET generation=excluded.generation, offset=excluded.offset",
+                row,
+            )
+            self.connection.commit()
+
+    def rollback(self) -> None:
+        rows = self.connection.execute(
+            "SELECT stream_id, generation, offset FROM checkpoint_state ORDER BY stream_id"
+        ).fetchall()
+        for row in rows:
+            self.connection.execute(
+                "INSERT INTO checkpoints VALUES (?, ?, ?) "
+                "ON CONFLICT(stream_id) DO UPDATE SET generation=excluded.generation, offset=excluded.offset",
+                row,
+            )
+            self.connection.commit()
+        self.connection.execute("DROP TABLE checkpoint_state")
+        self.connection.commit()
+
+    def write_current(self, checkpoint: Checkpoint) -> None:
+        self.connection.execute(
+            "INSERT INTO checkpoint_state VALUES (?, ?, ?) "
+            "ON CONFLICT(stream_id) DO UPDATE SET generation=excluded.generation, offset=excluded.offset",
+            (checkpoint.stream_id, checkpoint.generation, checkpoint.offset),
+        )
+        self.connection.commit()
+
+    def read_legacy(self, stream_id: str) -> Checkpoint | None:
+        row = self.connection.execute(
+            "SELECT stream_id, generation, offset FROM checkpoints WHERE stream_id=?",
+            (stream_id,),
+        ).fetchone()
+        return Checkpoint(*row) if row is not None else None
+
+    def read_current(self, stream_id: str) -> Checkpoint | None:
+        row = self.connection.execute(
+            "SELECT stream_id, generation, offset FROM checkpoint_state WHERE stream_id=?",
+            (stream_id,),
+        ).fetchone()
+        return Checkpoint(*row) if row is not None else None

--- a/tests/test_release_checkpoint_store.py
+++ b/tests/test_release_checkpoint_store.py
@@ -1,0 +1,42 @@
+import sqlite3
+
+from src.checkpoint_models import Checkpoint
+from src.release_checkpoint_store import CheckpointMigration
+
+
+def migration_with_legacy_checkpoint():
+    connection = sqlite3.connect(":memory:")
+    migration = CheckpointMigration(connection)
+    migration.initialize_legacy()
+    connection.execute("INSERT INTO checkpoints VALUES ('billing', 4, 91)")
+    connection.commit()
+    return migration
+
+
+def test_upgrade_copies_legacy_checkpoint():
+    migration = migration_with_legacy_checkpoint()
+
+    migration.upgrade()
+
+    assert migration.read_current("billing") == Checkpoint("billing", 4, 91)
+
+
+def test_rollback_copies_current_checkpoint_for_old_worker():
+    migration = migration_with_legacy_checkpoint()
+    migration.upgrade()
+    migration.write_current(Checkpoint("billing", 5, 2))
+
+    migration.rollback()
+
+    assert migration.read_legacy("billing") == Checkpoint("billing", 5, 2)
+
+
+def test_upgrade_can_run_again_after_rollback():
+    migration = migration_with_legacy_checkpoint()
+    migration.upgrade()
+    migration.write_current(Checkpoint("billing", 5, 2))
+    migration.rollback()
+
+    migration.upgrade()
+
+    assert migration.read_current("billing") == Checkpoint("billing", 5, 2)


### PR DESCRIPTION
Provide explicit upgrade and rollback operations between legacy `checkpoints` and current `checkpoint_state` storage. A later upgrade can run after rollback.

The draft focuses on reversible schema movement rather than transactional batch application.