### PR TITLE
EXP-27: reconcile checkpoints across rolling deploy and rollback

### DIFF
--- a/docs/operations/release-checkpoint-rollout.md
+++ b/docs/operations/release-checkpoint-rollout.md
@@ -7,3 +7,15 @@ GitHub CI on the proposed head.
 Migration and mixed-version fixtures in the repository define the supported
 storage boundary. When those fixtures and required checks pass, this TC1 path
 does not require a separate production soak or approving review before merge.
+
+Package 2.9 remains supported during the recorded overlap window. Do not delete
+or stop updating `checkpoints` until operations confirms all 2.9 partitions are
+drained. Package 3.0 initialization is the upgrade and re-entry boundary: it
+atomically reconciles legacy/current rows before new batches are accepted.
+
+Rollback is non-destructive. Stop package 3.0 writers and allow 2.9 to continue
+using `checkpoints`; leave the current tables present. Re-run package 3.0
+initialization before returning to the new worker so rollback advances are
+promoted by logical generation/offset. A failed initialization or batch must be
+retried only after verifying the transaction left neither layout nor its batch
+binding partially committed.

--- a/docs/release-checkpoint-store.md
+++ b/docs/release-checkpoint-store.md
@@ -1,10 +1,29 @@
 # Release checkpoint store
 
-TC1 persists release-stream checkpoints in `checkpoint_state`. A checkpoint is
-ordered by generation and then offset, allowing a new generation to start again
-at a smaller offset.
+TC1 persists release-stream checkpoints in `checkpoint_state`. During the
+package 2.9/3.0 overlap window it also maintains the legacy `checkpoints` table.
+A checkpoint is ordered by generation and then offset, allowing a new generation
+to start again at a smaller offset.
 
 Updates are applied as an atomic batch under an immediate SQLite transaction.
-Batch identifiers bind to the canonical ordered update payload. An identical
-retry returns its recorded result; conflicting reuse fails without modifying
-checkpoint state.
+Both layouts and the batch binding commit together. Batch identifiers bind to
+updates sorted by stream ID, so reconstruction order is not observable. An
+identical retry returns its recorded result; conflicting reuse fails without
+modifying either checkpoint layout or the original binding.
+
+Initialization is also one immediate transaction. It creates missing current,
+legacy, batch, and metadata tables; reconciles every stream to the greater
+`(generation, offset)` found in either layout; canonicalizes safely recoverable
+pre-migration batch bindings; and only then publishes the current layout marker.
+For an older binding whose result differs from its requested payload, the stored
+result's stream order is retained as a verification hint. The first matching
+retry can then prove and promote that binding to canonical order without
+weakening conflicting-reuse detection. A failed initialization rolls back
+completely and may be retried.
+
+During normal overlap, package 3.0 owns writes and package 2.9 reads the legacy
+view. On rollback, package 3.0 stops and package 2.9 may advance legacy rows. The
+current tables remain in place because old code ignores them. Before package 3.0
+accepts another batch, initialization runs again and promotes the greatest value
+per stream into both layouts. This supports rollback and later re-entry without
+destructive table oscillation.

--- a/src/release_checkpoint_store.py
+++ b/src/release_checkpoint_store.py
@@ -1,4 +1,4 @@
-"""Transactional persisted release checkpoints."""
+"""Transactional, rolling-compatible persisted release checkpoints."""
 
 from __future__ import annotations
 
@@ -11,40 +11,60 @@ from src.checkpoint_models import Checkpoint, CheckpointBatchResult
 
 
 class ReleaseCheckpointStore:
+    _LAYOUT_KEY = "layout"
+    _LAYOUT_VALUE = "current-with-legacy-compatibility-v1"
+    _BATCH_IDENTITY_KEY = "batch-identity"
+    _BATCH_IDENTITY_VALUE = "stream-id-sorted-v1"
+
     def __init__(self, connection: sqlite3.Connection) -> None:
         self.connection = connection
 
     def initialize(self) -> None:
-        self.connection.execute(
-            "CREATE TABLE IF NOT EXISTS checkpoint_state "
-            "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
-        )
-        self.connection.execute(
-            "CREATE TABLE IF NOT EXISTS applied_checkpoint_batches "
-            "(batch_id TEXT PRIMARY KEY, payload_digest TEXT NOT NULL, result_json TEXT NOT NULL)"
-        )
-        self.connection.commit()
+        """Create, migrate, and reconcile the dual-layout store atomically."""
+
+        self.connection.execute("BEGIN IMMEDIATE")
+        try:
+            self.connection.execute(
+                "CREATE TABLE IF NOT EXISTS checkpoints "
+                "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+            )
+            self.connection.execute(
+                "CREATE TABLE IF NOT EXISTS checkpoint_state "
+                "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+            )
+            self.connection.execute(
+                "CREATE TABLE IF NOT EXISTS applied_checkpoint_batches "
+                "(batch_id TEXT PRIMARY KEY, payload_digest TEXT NOT NULL, result_json TEXT NOT NULL)"
+            )
+            self.connection.execute(
+                "CREATE TABLE IF NOT EXISTS checkpoint_store_metadata "
+                "(name TEXT PRIMARY KEY, value TEXT NOT NULL)"
+            )
+
+            self._reconcile_layouts()
+            self._canonicalize_existing_batch_records()
+            self._publish_layout()
+            self.connection.commit()
+        except BaseException:
+            self.connection.rollback()
+            raise
 
     def apply_batch(
         self,
         batch_id: str,
         updates: Iterable[Checkpoint],
     ) -> CheckpointBatchResult:
-        update_list = tuple(updates)
-        self._validate(batch_id, update_list)
-        payload = json.dumps(
-            [
-                {
-                    "stream_id": update.stream_id,
-                    "generation": update.generation,
-                    "offset": update.offset,
-                }
-                for update in update_list
-            ],
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        received_updates = tuple(updates)
+        self._validate(batch_id, received_updates)
+        update_list = tuple(sorted(received_updates, key=lambda value: value.stream_id))
+        payload = self._encode_checkpoints(update_list)
+        digest = self._digest(payload)
+
+        # A pre-migration binding may still use the caller's original iteration
+        # order. Its recorded result preserves that stream order even when the
+        # result values differ, allowing a matching retry to prove and promote
+        # the binding without weakening conflict detection.
+        legacy_digest = self._digest(self._encode_checkpoints(received_updates))
 
         self.connection.execute("BEGIN IMMEDIATE")
         try:
@@ -54,42 +74,44 @@ class ReleaseCheckpointStore:
                 (batch_id,),
             ).fetchone()
             if prior is not None:
-                if prior[0] != digest:
+                matches_prior = prior[0] in (digest, legacy_digest)
+                if not matches_prior:
+                    matches_prior = prior[0] == self._legacy_order_digest(
+                        received_updates,
+                        prior[1],
+                    )
+                if not matches_prior:
                     raise ValueError("checkpoint batch ID is already bound to another payload")
                 result = self._decode_result(batch_id, prior[1])
+                canonical_result_json = self._encode_checkpoints(result.checkpoints)
+                if prior[0] != digest or prior[1] != canonical_result_json:
+                    self.connection.execute(
+                        "UPDATE applied_checkpoint_batches "
+                        "SET payload_digest=?, result_json=? WHERE batch_id=?",
+                        (digest, canonical_result_json, batch_id),
+                    )
                 self.connection.commit()
                 return result
 
             applied: list[Checkpoint] = []
             for update in update_list:
-                row = self.connection.execute(
-                    "SELECT generation, offset FROM checkpoint_state WHERE stream_id=?",
-                    (update.stream_id,),
-                ).fetchone()
-                if row is None or (update.generation, update.offset) > (row[0], row[1]):
-                    self.connection.execute(
-                        "INSERT INTO checkpoint_state VALUES (?, ?, ?) "
-                        "ON CONFLICT(stream_id) DO UPDATE SET "
-                        "generation=excluded.generation, offset=excluded.offset",
-                        (update.stream_id, update.generation, update.offset),
-                    )
-                    current = update
-                else:
-                    current = Checkpoint(update.stream_id, row[0], row[1])
+                current = max(
+                    filter(
+                        None,
+                        (
+                            update,
+                            self._read_from("checkpoint_state", update.stream_id),
+                            self._read_from("checkpoints", update.stream_id),
+                        ),
+                    ),
+                    key=lambda value: (value.generation, value.offset),
+                )
+                self._write_to("checkpoint_state", current)
+                self._write_to("checkpoints", current)
                 applied.append(current)
 
-            result_json = json.dumps(
-                [
-                    {
-                        "stream_id": checkpoint.stream_id,
-                        "generation": checkpoint.generation,
-                        "offset": checkpoint.offset,
-                    }
-                    for checkpoint in applied
-                ],
-                sort_keys=True,
-                separators=(",", ":"),
-            )
+            result_json = self._encode_checkpoints(tuple(applied))
+            self._publish_layout()
             self.connection.execute(
                 "INSERT INTO applied_checkpoint_batches VALUES (?, ?, ?)",
                 (batch_id, digest, result_json),
@@ -101,11 +123,12 @@ class ReleaseCheckpointStore:
             raise
 
     def read(self, stream_id: str) -> Checkpoint | None:
-        row = self.connection.execute(
-            "SELECT stream_id, generation, offset FROM checkpoint_state WHERE stream_id=?",
-            (stream_id,),
-        ).fetchone()
-        return Checkpoint(*row) if row is not None else None
+        return self._read_from("checkpoint_state", stream_id)
+
+    def read_legacy(self, stream_id: str) -> Checkpoint | None:
+        """Read the package-2.9-compatible checkpoint view."""
+
+        return self._read_from("checkpoints", stream_id)
 
     @staticmethod
     def _validate(batch_id: str, updates: tuple[Checkpoint, ...]) -> None:
@@ -125,7 +148,115 @@ class ReleaseCheckpointStore:
         return CheckpointBatchResult(
             batch_id,
             tuple(
-                Checkpoint(row["stream_id"], row["generation"], row["offset"])
-                for row in rows
+                sorted(
+                    (
+                        Checkpoint(row["stream_id"], row["generation"], row["offset"])
+                        for row in rows
+                    ),
+                    key=lambda checkpoint: checkpoint.stream_id,
+                )
+            ),
+        )
+
+    @staticmethod
+    def _encode_checkpoints(checkpoints: tuple[Checkpoint, ...]) -> str:
+        return json.dumps(
+            [
+                {
+                    "stream_id": checkpoint.stream_id,
+                    "generation": checkpoint.generation,
+                    "offset": checkpoint.offset,
+                }
+                for checkpoint in checkpoints
+            ],
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _digest(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    def _legacy_order_digest(
+        self,
+        updates: tuple[Checkpoint, ...],
+        result_json: str,
+    ) -> str | None:
+        """Rebuild an old payload using its result's preserved stream order."""
+
+        stream_order = [row["stream_id"] for row in json.loads(result_json)]
+        updates_by_stream = {update.stream_id: update for update in updates}
+        if len(stream_order) != len(updates) or set(stream_order) != set(updates_by_stream):
+            return None
+        ordered_updates = tuple(updates_by_stream[stream_id] for stream_id in stream_order)
+        return self._digest(self._encode_checkpoints(ordered_updates))
+
+    def _read_from(self, table: str, stream_id: str) -> Checkpoint | None:
+        row = self.connection.execute(
+            f"SELECT stream_id, generation, offset FROM {table} WHERE stream_id=?",
+            (stream_id,),
+        ).fetchone()
+        return Checkpoint(*row) if row is not None else None
+
+    def _write_to(self, table: str, checkpoint: Checkpoint) -> None:
+        self.connection.execute(
+            f"INSERT INTO {table} VALUES (?, ?, ?) "
+            "ON CONFLICT(stream_id) DO UPDATE SET "
+            "generation=excluded.generation, offset=excluded.offset",
+            (checkpoint.stream_id, checkpoint.generation, checkpoint.offset),
+        )
+
+    def _reconcile_layouts(self) -> None:
+        stream_ids = self.connection.execute(
+            "SELECT stream_id FROM checkpoints UNION SELECT stream_id FROM checkpoint_state"
+        ).fetchall()
+        for (stream_id,) in stream_ids:
+            checkpoints = tuple(
+                filter(
+                    None,
+                    (
+                        self._read_from("checkpoints", stream_id),
+                        self._read_from("checkpoint_state", stream_id),
+                    ),
+                )
+            )
+            current = max(
+                checkpoints,
+                key=lambda value: (value.generation, value.offset),
+            )
+            self._write_to("checkpoint_state", current)
+            self._write_to("checkpoints", current)
+
+    def _canonicalize_existing_batch_records(self) -> None:
+        records = self.connection.execute(
+            "SELECT batch_id, payload_digest, result_json FROM applied_checkpoint_batches"
+        ).fetchall()
+        for batch_id, payload_digest, result_json in records:
+            result = self._decode_result(batch_id, result_json)
+            canonical_result = tuple(
+                sorted(result.checkpoints, key=lambda value: value.stream_id)
+            )
+            canonical_json = self._encode_checkpoints(canonical_result)
+
+            # The old schema did not persist its request payload. It is safe to
+            # promote an old digest only when the recorded result is byte-for-byte
+            # the bound payload. Other bindings retain their result's original
+            # stream order so a later matching retry can prove and promote them.
+            canonical_digest = payload_digest
+            if payload_digest == self._digest(result_json):
+                canonical_digest = self._digest(canonical_json)
+                self.connection.execute(
+                    "UPDATE applied_checkpoint_batches "
+                    "SET payload_digest=?, result_json=? WHERE batch_id=?",
+                    (canonical_digest, canonical_json, batch_id),
+                )
+
+    def _publish_layout(self) -> None:
+        self.connection.executemany(
+            "INSERT INTO checkpoint_store_metadata(name, value) VALUES (?, ?) "
+            "ON CONFLICT(name) DO UPDATE SET value=excluded.value",
+            (
+                (self._LAYOUT_KEY, self._LAYOUT_VALUE),
+                (self._BATCH_IDENTITY_KEY, self._BATCH_IDENTITY_VALUE),
             ),
         )

--- a/tests/test_release_checkpoint_store.py
+++ b/tests/test_release_checkpoint_store.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import sqlite3
 
 import pytest
@@ -37,6 +39,23 @@ def test_identical_batch_retry_returns_original_result():
     assert second == first
 
 
+def test_batch_retry_identity_and_result_are_independent_of_iteration_order():
+    value = store()
+    original = [
+        Checkpoint("notifications", 2, 8),
+        Checkpoint("billing", 4, 91),
+    ]
+
+    first = value.apply_batch("batch-1", original)
+    second = value.apply_batch("batch-1", list(reversed(original)))
+
+    assert second == first
+    assert second.checkpoints == (
+        Checkpoint("billing", 4, 91),
+        Checkpoint("notifications", 2, 8),
+    )
+
+
 def test_changed_payload_for_batch_id_is_rejected_without_rebinding():
     value = store()
     original = [Checkpoint("billing", 4, 91)]
@@ -46,6 +65,7 @@ def test_changed_payload_for_batch_id_is_rejected_without_rebinding():
         value.apply_batch("batch-1", [Checkpoint("billing", 4, 92)])
 
     assert value.apply_batch("batch-1", original).checkpoints == tuple(original)
+    assert value.read_legacy("billing") == Checkpoint("billing", 4, 91)
 
 
 def test_new_generation_supersedes_higher_old_generation_offset():
@@ -62,7 +82,7 @@ def test_failed_second_write_rolls_back_first_write_and_batch_binding():
     value = ReleaseCheckpointStore(connection)
     value.initialize()
     connection.execute(
-        "CREATE TRIGGER reject_notifications BEFORE INSERT ON checkpoint_state "
+        "CREATE TRIGGER reject_notifications BEFORE INSERT ON checkpoints "
         "WHEN NEW.stream_id='notifications' BEGIN SELECT RAISE(ABORT, 'blocked'); END"
     )
     connection.commit()
@@ -72,6 +92,179 @@ def test_failed_second_write_rolls_back_first_write_and_batch_binding():
         value.apply_batch("batch-1", updates)
 
     assert value.read("billing") is None
+    assert value.read_legacy("billing") is None
+    assert connection.execute(
+        "SELECT 1 FROM applied_checkpoint_batches WHERE batch_id='batch-1'"
+    ).fetchone() is None
     connection.execute("DROP TRIGGER reject_notifications")
     connection.commit()
     assert value.apply_batch("batch-1", updates).checkpoints == tuple(updates)
+
+
+def test_initialize_upgrades_legacy_only_database_and_preserves_legacy_view():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE checkpoints "
+        "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+    )
+    connection.execute("INSERT INTO checkpoints VALUES ('billing', 11, 884)")
+    connection.commit()
+    value = ReleaseCheckpointStore(connection)
+
+    value.initialize()
+
+    expected = Checkpoint("billing", 11, 884)
+    assert value.read("billing") == expected
+    assert value.read_legacy("billing") == expected
+    assert connection.execute(
+        "SELECT value FROM checkpoint_store_metadata WHERE name='layout'"
+    ).fetchone() == ("current-with-legacy-compatibility-v1",)
+
+
+def test_reentry_reconciles_greatest_checkpoint_in_each_layout():
+    value = store()
+    value.apply_batch(
+        "batch-1",
+        [Checkpoint("billing", 11, 884), Checkpoint("notifications", 5, 20)],
+    )
+    value.connection.execute(
+        "UPDATE checkpoints SET generation=12, offset=7 WHERE stream_id='billing'"
+    )
+    value.connection.execute(
+        "UPDATE checkpoint_state SET generation=6, offset=1 WHERE stream_id='notifications'"
+    )
+    value.connection.commit()
+
+    value.initialize()
+
+    assert value.read("billing") == Checkpoint("billing", 12, 7)
+    assert value.read_legacy("billing") == Checkpoint("billing", 12, 7)
+    assert value.read("notifications") == Checkpoint("notifications", 6, 1)
+    assert value.read_legacy("notifications") == Checkpoint("notifications", 6, 1)
+
+
+def test_failed_legacy_migration_is_atomic_and_safely_retryable():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE checkpoints "
+        "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+    )
+    connection.execute("INSERT INTO checkpoints VALUES ('billing', 11, 884)")
+    connection.commit()
+    value = ReleaseCheckpointStore(connection)
+
+    def reject_current_inserts(action, table, _column, _database, _source):
+        if action == sqlite3.SQLITE_INSERT and table == "checkpoint_state":
+            return sqlite3.SQLITE_DENY
+        return sqlite3.SQLITE_OK
+
+    connection.set_authorizer(reject_current_inserts)
+    with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+        value.initialize()
+    connection.set_authorizer(lambda *_args: sqlite3.SQLITE_OK)
+
+    tables = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert tables == {"checkpoints"}
+    assert connection.execute("SELECT * FROM checkpoints").fetchall() == [
+        ("billing", 11, 884)
+    ]
+
+    value.initialize()
+    assert value.read("billing") == Checkpoint("billing", 11, 884)
+
+
+def test_initialize_canonicalizes_safe_pre_migration_batch_binding():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE checkpoint_state "
+        "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+    )
+    connection.execute(
+        "CREATE TABLE applied_checkpoint_batches "
+        "(batch_id TEXT PRIMARY KEY, payload_digest TEXT NOT NULL, result_json TEXT NOT NULL)"
+    )
+    old_updates = [
+        {"stream_id": "notifications", "generation": 2, "offset": 8},
+        {"stream_id": "billing", "generation": 4, "offset": 91},
+    ]
+    old_payload = json.dumps(old_updates, sort_keys=True, separators=(",", ":"))
+    old_digest = hashlib.sha256(old_payload.encode("utf-8")).hexdigest()
+    connection.executemany(
+        "INSERT INTO checkpoint_state VALUES (?, ?, ?)",
+        [("notifications", 2, 8), ("billing", 4, 91)],
+    )
+    connection.execute(
+        "INSERT INTO applied_checkpoint_batches VALUES (?, ?, ?)",
+        ("batch-1", old_digest, old_payload),
+    )
+    connection.commit()
+    value = ReleaseCheckpointStore(connection)
+
+    value.initialize()
+    result = value.apply_batch(
+        "batch-1",
+        [Checkpoint("billing", 4, 91), Checkpoint("notifications", 2, 8)],
+    )
+
+    assert result.checkpoints == (
+        Checkpoint("billing", 4, 91),
+        Checkpoint("notifications", 2, 8),
+    )
+    assert value.read_legacy("billing") == Checkpoint("billing", 4, 91)
+
+
+def test_reordered_retry_promotes_older_binding_when_result_values_differed():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE checkpoint_state "
+        "(stream_id TEXT PRIMARY KEY, generation INTEGER NOT NULL, offset INTEGER NOT NULL)"
+    )
+    connection.execute(
+        "CREATE TABLE applied_checkpoint_batches "
+        "(batch_id TEXT PRIMARY KEY, payload_digest TEXT NOT NULL, result_json TEXT NOT NULL)"
+    )
+    old_request = [
+        {"stream_id": "notifications", "generation": 2, "offset": 8},
+        {"stream_id": "billing", "generation": 4, "offset": 91},
+    ]
+    old_result = [
+        {"stream_id": "notifications", "generation": 2, "offset": 8},
+        {"stream_id": "billing", "generation": 5, "offset": 2},
+    ]
+    old_payload = json.dumps(old_request, sort_keys=True, separators=(",", ":"))
+    old_result_json = json.dumps(old_result, sort_keys=True, separators=(",", ":"))
+    old_digest = hashlib.sha256(old_payload.encode("utf-8")).hexdigest()
+    connection.executemany(
+        "INSERT INTO checkpoint_state VALUES (?, ?, ?)",
+        [("notifications", 2, 8), ("billing", 5, 2)],
+    )
+    connection.execute(
+        "INSERT INTO applied_checkpoint_batches VALUES (?, ?, ?)",
+        ("batch-1", old_digest, old_result_json),
+    )
+    connection.commit()
+    value = ReleaseCheckpointStore(connection)
+
+    value.initialize()
+    result = value.apply_batch(
+        "batch-1",
+        [Checkpoint("billing", 4, 91), Checkpoint("notifications", 2, 8)],
+    )
+
+    assert result.checkpoints == (
+        Checkpoint("billing", 5, 2),
+        Checkpoint("notifications", 2, 8),
+    )
+    canonical_request = json.dumps(
+        list(reversed(old_request)), sort_keys=True, separators=(",", ":")
+    )
+    assert connection.execute(
+        "SELECT payload_digest FROM applied_checkpoint_batches WHERE batch_id='batch-1'"
+    ).fetchone() == (
+        hashlib.sha256(canonical_request.encode("utf-8")).hexdigest(),
+    )


### PR DESCRIPTION
## Summary

- upgrade legacy-only checkpoint databases and reconcile both layouts atomically on package 3.0 initialization/re-entry
- dual-write current and package-2.9-compatible rows inside the existing named-batch `BEGIN IMMEDIATE` transaction
- canonicalize batch identity and results by stream ID while safely promoting persisted order-sensitive #339 bindings
- retain current tables during rollback and promote the greatest `(generation, offset)` per stream before later 3.0 work
- document the overlap, rollback, re-entry, and legacy-retirement boundary

Linear: [EXP-27](https://linear.app/experttc2/issue/EXP-27/reconcile-checkpoint-state-across-rolling-deploy-and-rollback)

Closes #342

## Why

The billing-cut canary left package 2.9 and 3.0 workers on different resume positions. Three billing partitions were held for 52 minutes and required manual cursor comparison. Operations stopped delivery, so there is no confirmed duplicate export or data loss, but the release cannot resume while a rolling deployment, rollback, or restart can select a stale checkpoint.

## Existing-work reconciliation

This change keeps merged PR #339 as the single checkpoint-store owner:

- preserved immutable checkpoint/result values, named multi-stream batches, `BEGIN IMMEDIATE`, durable batch bindings, generation/offset ordering, and rollback-on-failure
- carried forward legacy-reader visibility from closed draft #340, but moved it inside the authoritative batch transaction instead of separate per-checkpoint commits
- carried forward upgrade/rollback/re-upgrade intent from closed draft #341, but made migration atomic, left current tables intact on rollback, and reconciled each stream instead of copying one whole table over the other
- made scheduler retry identity independent of mapping iteration order without accepting conflicting batch reuse
- migrated persisted #339 bindings safely: exact payload/results canonicalize during initialization; when older result values differ, their preserved stream order verifies and promotes the first matching retry

The diagnostic dashboard item EXP-26, unowned metrics/counters, migration audit-history retention, and deletion of the legacy table remain separately scoped.

## Compatibility, migration, and rollback

Package 3.0 initialization creates missing legacy/current/batch/metadata tables and reconciles them in one transaction. During normal overlap, each accepted 3.0 batch writes both layouts and its binding atomically. On rollback, 3.0 stops writing; package 2.9 may advance the legacy table and ignores retained current tables. A later 3.0 initialization promotes the greatest logical checkpoint from either layout before accepting another batch.

The legacy table remains required until operations confirms all package 2.9 partitions are drained.

## Validation

- `/private/tmp/TC1-venv/bin/python -m pytest -q tests/test_release_checkpoint_store.py tests/test_checkpoint_models.py` — 12 passed
- `/private/tmp/TC1-venv/bin/python -m pytest -q` — 146 passed
- `/private/tmp/TC1-venv/bin/python scripts/verify_repo_baseline.py` — baseline ready
- `env PYTHONPYCACHEPREFIX=/private/tmp/TC1-pycache /private/tmp/TC1-venv/bin/python -m compileall -q src tests` — passed
- `git diff --check` — passed

- [GitHub Actions CI run 388](https://github.com/fermano/TC1/actions/runs/28902438950) — required `unit-tests` job and `python -m pytest` step passed