### PR TITLE
Fence concurrent release promotion owners

### DIFF
--- a/docs/operations/promotion-lease-rollout.md
+++ b/docs/operations/promotion-lease-rollout.md
@@ -1,0 +1,8 @@
+# Promotion lease rollout checks
+
+Promotion-lease changes require the focused lease/model suite, the full
+repository suite, baseline verification, diff checks, and required GitHub CI.
+
+The checked-in worker fixtures define the supported database boundary. This TC1
+path has no additional production-soak or approving-review gate when those
+checks pass and the current pull request has no unresolved material discussion.

--- a/docs/promotion-leases.md
+++ b/docs/promotion-leases.md
@@ -1,0 +1,6 @@
+# Promotion lease fencing
+
+Promotion workers acquire a lease containing a monotonically increasing fence.
+Before publishing, a worker checks that its owner and fence still match the
+current row and that the lease has not expired. Takeover and renewal advance the
+fence under an immediate SQLite transaction.

--- a/src/promotion_lease_models.py
+++ b/src/promotion_lease_models.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromotionLease:
+    resource: str
+    owner: str
+    fence: int
+    expires_at: int

--- a/src/promotion_lease_store.py
+++ b/src/promotion_lease_store.py
@@ -1,0 +1,54 @@
+import sqlite3
+
+from src.promotion_lease_models import PromotionLease
+
+
+class PromotionLeaseStore:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+
+    def initialize(self) -> None:
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS promotion_fences "
+            "(resource TEXT PRIMARY KEY, owner TEXT NOT NULL, "
+            "fence INTEGER NOT NULL, expires_at INTEGER NOT NULL)"
+        )
+        self.connection.commit()
+
+    def acquire(self, resource: str, owner: str, ttl: int, now: int) -> PromotionLease | None:
+        self.connection.execute("BEGIN IMMEDIATE")
+        try:
+            row = self.connection.execute(
+                "SELECT owner, fence, expires_at FROM promotion_fences WHERE resource=?",
+                (resource,),
+            ).fetchone()
+            if row is not None and row[2] > now and row[0] != owner:
+                self.connection.commit()
+                return None
+            fence = 1 if row is None else row[1] + 1
+            lease = PromotionLease(resource, owner, fence, now + ttl)
+            self.connection.execute(
+                "INSERT INTO promotion_fences VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(resource) DO UPDATE SET owner=excluded.owner, "
+                "fence=excluded.fence, expires_at=excluded.expires_at",
+                (lease.resource, lease.owner, lease.fence, lease.expires_at),
+            )
+            self.connection.commit()
+            return lease
+        except BaseException:
+            self.connection.rollback()
+            raise
+
+    def can_publish(self, resource: str, owner: str, fence: int, now: int) -> bool:
+        row = self.connection.execute(
+            "SELECT owner, fence, expires_at FROM promotion_fences WHERE resource=?",
+            (resource,),
+        ).fetchone()
+        return row == (owner, fence, row[2]) and row[2] > now if row is not None else False
+
+    def read(self, resource: str) -> PromotionLease | None:
+        row = self.connection.execute(
+            "SELECT resource, owner, fence, expires_at FROM promotion_fences WHERE resource=?",
+            (resource,),
+        ).fetchone()
+        return PromotionLease(*row) if row is not None else None

--- a/tests/test_promotion_lease_models.py
+++ b/tests/test_promotion_lease_models.py
@@ -1,0 +1,12 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from src.promotion_lease_models import PromotionLease
+
+
+def test_promotion_lease_is_immutable():
+    lease = PromotionLease("rc-17", "worker-a", 1, 130)
+
+    with pytest.raises(FrozenInstanceError):
+        lease.fence = 2

--- a/tests/test_promotion_lease_store.py
+++ b/tests/test_promotion_lease_store.py
@@ -1,5 +1,7 @@
 import sqlite3
 
+import pytest
+
 from src.promotion_lease_models import PromotionLease
 from src.promotion_lease_store import PromotionLeaseStore
 
@@ -40,3 +42,18 @@ def test_same_owner_renewal_also_increments_fence():
     second = value.acquire("rc-17", "worker-a", 30, 110)
 
     assert second.fence == first.fence + 1
+
+
+def test_failed_takeover_keeps_prior_fence():
+    value = store()
+    original = value.acquire("rc-17", "worker-a", 30, 100)
+    value.connection.execute(
+        "CREATE TRIGGER reject_worker_b BEFORE UPDATE ON promotion_fences "
+        "WHEN NEW.owner='worker-b' BEGIN SELECT RAISE(ABORT, 'blocked'); END"
+    )
+    value.connection.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="blocked"):
+        value.acquire("rc-17", "worker-b", 30, 131)
+
+    assert value.read("rc-17") == original

--- a/tests/test_promotion_lease_store.py
+++ b/tests/test_promotion_lease_store.py
@@ -1,0 +1,42 @@
+import sqlite3
+
+from src.promotion_lease_models import PromotionLease
+from src.promotion_lease_store import PromotionLeaseStore
+
+
+def store():
+    connection = sqlite3.connect(":memory:")
+    value = PromotionLeaseStore(connection)
+    value.initialize()
+    return value
+
+
+def test_first_owner_receives_first_fence():
+    value = store()
+    assert value.acquire("rc-17", "worker-a", 30, 100) == PromotionLease(
+        "rc-17", "worker-a", 1, 130
+    )
+
+
+def test_unexpired_lease_blocks_different_owner():
+    value = store()
+    value.acquire("rc-17", "worker-a", 30, 100)
+    assert value.acquire("rc-17", "worker-b", 30, 110) is None
+
+
+def test_takeover_increments_fence_and_rejects_stale_publisher():
+    value = store()
+    old = value.acquire("rc-17", "worker-a", 30, 100)
+    new = value.acquire("rc-17", "worker-b", 30, 131)
+
+    assert new.fence == 2
+    assert value.can_publish("rc-17", old.owner, old.fence, 132) is False
+    assert value.can_publish("rc-17", new.owner, new.fence, 132) is True
+
+
+def test_same_owner_renewal_also_increments_fence():
+    value = store()
+    first = value.acquire("rc-17", "worker-a", 30, 100)
+    second = value.acquire("rc-17", "worker-a", 30, 110)
+
+    assert second.fence == first.fence + 1


### PR DESCRIPTION
Persist promotion ownership with an incrementing fence and verify the current fence immediately before publish. Acquisition and takeover run under an immediate SQLite transaction.

The implementation uses promotion_fences as its storage boundary.