### PR TITLE
Keep promotion leases visible to existing operations readers

### DIFF
--- a/docs/promotion-leases.md
+++ b/docs/promotion-leases.md
@@ -1,0 +1,5 @@
+# Promotion leases
+
+Promotion workers coordinate through the `promotion_leases` table. A row records
+the resource, owner, and expiry timestamp consumed by the existing operations
+viewer. A different owner may replace an expired row.

--- a/src/promotion_lease_models.py
+++ b/src/promotion_lease_models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromotionLease:
+    resource: str
+    owner: str
+    expires_at: int

--- a/src/promotion_lease_store.py
+++ b/src/promotion_lease_store.py
@@ -1,0 +1,38 @@
+import sqlite3
+
+from src.promotion_lease_models import PromotionLease
+
+
+class PromotionLeaseStore:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+
+    def initialize(self) -> None:
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS promotion_leases "
+            "(resource TEXT PRIMARY KEY, owner TEXT NOT NULL, expires_at INTEGER NOT NULL)"
+        )
+        self.connection.commit()
+
+    def acquire(self, resource: str, owner: str, ttl: int, now: int) -> PromotionLease | None:
+        row = self.connection.execute(
+            "SELECT owner, expires_at FROM promotion_leases WHERE resource=?",
+            (resource,),
+        ).fetchone()
+        if row is not None and row[1] > now and row[0] != owner:
+            return None
+        lease = PromotionLease(resource, owner, now + ttl)
+        self.connection.execute(
+            "INSERT INTO promotion_leases VALUES (?, ?, ?) "
+            "ON CONFLICT(resource) DO UPDATE SET owner=excluded.owner, expires_at=excluded.expires_at",
+            (lease.resource, lease.owner, lease.expires_at),
+        )
+        self.connection.commit()
+        return lease
+
+    def read(self, resource: str) -> PromotionLease | None:
+        row = self.connection.execute(
+            "SELECT resource, owner, expires_at FROM promotion_leases WHERE resource=?",
+            (resource,),
+        ).fetchone()
+        return PromotionLease(*row) if row is not None else None

--- a/tests/test_promotion_lease_store.py
+++ b/tests/test_promotion_lease_store.py
@@ -1,0 +1,32 @@
+import sqlite3
+
+from src.promotion_lease_models import PromotionLease
+from src.promotion_lease_store import PromotionLeaseStore
+
+
+def store():
+    connection = sqlite3.connect(":memory:")
+    value = PromotionLeaseStore(connection)
+    value.initialize()
+    return value
+
+
+def test_owner_can_acquire_empty_lease():
+    value = store()
+    assert value.acquire("rc-17", "worker-a", 30, 100) == PromotionLease(
+        "rc-17", "worker-a", 130
+    )
+
+
+def test_other_owner_waits_for_unexpired_lease():
+    value = store()
+    value.acquire("rc-17", "worker-a", 30, 100)
+    assert value.acquire("rc-17", "worker-b", 30, 110) is None
+
+
+def test_other_owner_takes_over_expired_lease():
+    value = store()
+    value.acquire("rc-17", "worker-a", 30, 100)
+    assert value.acquire("rc-17", "worker-b", 30, 131) == PromotionLease(
+        "rc-17", "worker-b", 161
+    )


### PR DESCRIPTION
Persist promotion owner and expiry in the promotion_leases table consumed by the existing operations viewer. Includes acquire, wait, and takeover behavior using the worker's observed time.