### PR TITLE
Rebuild promotion ownership from lease events

### DIFF
--- a/docs/promotion-leases.md
+++ b/docs/promotion-leases.md
@@ -1,0 +1,5 @@
+# Promotion lease journal
+
+Lease changes are appended to `promotion_lease_events`. A restarted worker
+reconstructs current ownership from the highest event sequence for each release
+resource. Acquire and release history remains available for diagnosis.

--- a/src/promotion_lease_models.py
+++ b/src/promotion_lease_models.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromotionLeaseEvent:
+    sequence: int
+    resource: str
+    owner: str
+    expires_at: int
+    action: str

--- a/src/promotion_lease_store.py
+++ b/src/promotion_lease_store.py
@@ -1,0 +1,45 @@
+import sqlite3
+
+from src.promotion_lease_models import PromotionLeaseEvent
+
+
+class PromotionLeaseJournal:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+
+    def initialize(self) -> None:
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS promotion_lease_events "
+            "(sequence INTEGER PRIMARY KEY AUTOINCREMENT, resource TEXT NOT NULL, "
+            "owner TEXT NOT NULL, expires_at INTEGER NOT NULL, action TEXT NOT NULL)"
+        )
+        self.connection.commit()
+
+    def acquire(self, resource: str, owner: str, ttl: int, now: int) -> PromotionLeaseEvent | None:
+        current = self.current(resource)
+        if current is not None and current.action == "acquire" and current.expires_at > now:
+            return None
+        cursor = self.connection.execute(
+            "INSERT INTO promotion_lease_events(resource, owner, expires_at, action) "
+            "VALUES (?, ?, ?, 'acquire')",
+            (resource, owner, now + ttl),
+        )
+        self.connection.commit()
+        return PromotionLeaseEvent(cursor.lastrowid, resource, owner, now + ttl, "acquire")
+
+    def release(self, resource: str, owner: str, now: int) -> PromotionLeaseEvent:
+        cursor = self.connection.execute(
+            "INSERT INTO promotion_lease_events(resource, owner, expires_at, action) "
+            "VALUES (?, ?, ?, 'release')",
+            (resource, owner, now),
+        )
+        self.connection.commit()
+        return PromotionLeaseEvent(cursor.lastrowid, resource, owner, now, "release")
+
+    def current(self, resource: str) -> PromotionLeaseEvent | None:
+        row = self.connection.execute(
+            "SELECT sequence, resource, owner, expires_at, action "
+            "FROM promotion_lease_events WHERE resource=? ORDER BY sequence DESC LIMIT 1",
+            (resource,),
+        ).fetchone()
+        return PromotionLeaseEvent(*row) if row is not None else None

--- a/tests/test_promotion_lease_store.py
+++ b/tests/test_promotion_lease_store.py
@@ -1,0 +1,35 @@
+import sqlite3
+
+from src.promotion_lease_store import PromotionLeaseJournal
+
+
+def test_restart_replays_last_lease_event():
+    connection = sqlite3.connect(":memory:")
+    first = PromotionLeaseJournal(connection)
+    first.initialize()
+    first.acquire("rc-17", "worker-a", 30, 100)
+
+    restarted = PromotionLeaseJournal(connection)
+
+    assert restarted.current("rc-17").owner == "worker-a"
+
+
+def test_release_allows_later_owner():
+    connection = sqlite3.connect(":memory:")
+    value = PromotionLeaseJournal(connection)
+    value.initialize()
+    value.acquire("rc-17", "worker-a", 30, 100)
+    value.release("rc-17", "worker-a", 105)
+
+    acquired = value.acquire("rc-17", "worker-b", 30, 106)
+
+    assert acquired.owner == "worker-b"
+
+
+def test_unexpired_journal_entry_blocks_second_owner():
+    connection = sqlite3.connect(":memory:")
+    value = PromotionLeaseJournal(connection)
+    value.initialize()
+    value.acquire("rc-17", "worker-a", 30, 100)
+
+    assert value.acquire("rc-17", "worker-b", 30, 110) is None


### PR DESCRIPTION
Append acquire and release events and reconstruct current ownership by event sequence after worker restart. The journal retains history used during promotion incident review.