### PR TITLE
EXP-33: fence promotion takeover callbacks

### DIFF
--- a/docs/promotion-leases.md
+++ b/docs/promotion-leases.md
@@ -1,6 +1,12 @@
 # Promotion lease fencing
 
 Promotion workers acquire a lease containing a monotonically increasing fence.
-Before publishing, a worker checks that its owner and fence still match the
-current row and that the lease has not expired. Takeover and renewal advance the
-fence under an immediate SQLite transaction.
+SQLite's `unixepoch()` is the authority for expiry; the worker-time argument
+retained for package 5.1 compatibility is ignored. Acquisition, takeover, and
+renewal update the authoritative `promotion_fences` row and the package 4.6
+`promotion_leases` viewer row under one immediate transaction.
+
+A registry callback must check that its owner and fence still match the current
+unexpired row immediately before the callback is accepted. The check must be
+repeated when a queued callback resumes; an earlier successful check cannot be
+reused after a connection retry or worker recovery.

--- a/src/promotion_lease_store.py
+++ b/src/promotion_lease_store.py
@@ -8,30 +8,58 @@ class PromotionLeaseStore:
         self.connection = connection
 
     def initialize(self) -> None:
-        self.connection.execute(
-            "CREATE TABLE IF NOT EXISTS promotion_fences "
-            "(resource TEXT PRIMARY KEY, owner TEXT NOT NULL, "
-            "fence INTEGER NOT NULL, expires_at INTEGER NOT NULL)"
-        )
-        self.connection.commit()
-
-    def acquire(self, resource: str, owner: str, ttl: int, now: int) -> PromotionLease | None:
         self.connection.execute("BEGIN IMMEDIATE")
         try:
+            self.connection.execute(
+                "CREATE TABLE IF NOT EXISTS promotion_fences "
+                "(resource TEXT PRIMARY KEY, owner TEXT NOT NULL, "
+                "fence INTEGER NOT NULL, expires_at INTEGER NOT NULL)"
+            )
+            self.connection.execute(
+                "CREATE TABLE IF NOT EXISTS promotion_leases "
+                "(resource TEXT PRIMARY KEY, owner TEXT NOT NULL, "
+                "expires_at INTEGER NOT NULL)"
+            )
+            self.connection.execute(
+                "INSERT INTO promotion_leases(resource, owner, expires_at) "
+                "SELECT resource, owner, expires_at FROM promotion_fences WHERE 1 "
+                "ON CONFLICT(resource) DO UPDATE SET owner=excluded.owner, "
+                "expires_at=excluded.expires_at"
+            )
+            self.connection.commit()
+        except BaseException:
+            self.connection.rollback()
+            raise
+
+    def acquire(
+        self, resource: str, owner: str, ttl: int, now: int | None = None
+    ) -> PromotionLease | None:
+        # Package 5.1 callers still pass their observed time. Keep the argument
+        # for compatibility, but never use a worker clock as the lease boundary.
+        del now
+        self.connection.execute("BEGIN IMMEDIATE")
+        try:
+            database_now = self.connection.execute("SELECT unixepoch()").fetchone()[0]
             row = self.connection.execute(
                 "SELECT owner, fence, expires_at FROM promotion_fences WHERE resource=?",
                 (resource,),
             ).fetchone()
-            if row is not None and row[2] > now and row[0] != owner:
+            if row is not None and row[2] > database_now and row[0] != owner:
                 self.connection.commit()
                 return None
             fence = 1 if row is None else row[1] + 1
-            lease = PromotionLease(resource, owner, fence, now + ttl)
+            lease = PromotionLease(resource, owner, fence, database_now + ttl)
             self.connection.execute(
                 "INSERT INTO promotion_fences VALUES (?, ?, ?, ?) "
                 "ON CONFLICT(resource) DO UPDATE SET owner=excluded.owner, "
                 "fence=excluded.fence, expires_at=excluded.expires_at",
                 (lease.resource, lease.owner, lease.fence, lease.expires_at),
+            )
+            self.connection.execute(
+                "INSERT INTO promotion_leases VALUES (?, ?, ?) "
+                "ON CONFLICT(resource) DO UPDATE SET owner=excluded.owner, "
+                "expires_at=excluded.expires_at",
+                (lease.resource, lease.owner, lease.expires_at),
             )
             self.connection.commit()
             return lease
@@ -39,12 +67,19 @@ class PromotionLeaseStore:
             self.connection.rollback()
             raise
 
-    def can_publish(self, resource: str, owner: str, fence: int, now: int) -> bool:
+    def can_publish(
+        self, resource: str, owner: str, fence: int, now: int | None = None
+    ) -> bool:
+        # This check belongs at callback acceptance time, including after a
+        # queued callback resumes. The database evaluates ownership and expiry
+        # together so a corrected worker clock cannot revive a stale fence.
+        del now
         row = self.connection.execute(
-            "SELECT owner, fence, expires_at FROM promotion_fences WHERE resource=?",
-            (resource,),
+            "SELECT EXISTS(SELECT 1 FROM promotion_fences "
+            "WHERE resource=? AND owner=? AND fence=? AND expires_at > unixepoch())",
+            (resource, owner, fence),
         ).fetchone()
-        return row == (owner, fence, row[2]) and row[2] > now if row is not None else False
+        return row[0] == 1
 
     def read(self, resource: str) -> PromotionLease | None:
         row = self.connection.execute(

--- a/tests/test_promotion_lease_store.py
+++ b/tests/test_promotion_lease_store.py
@@ -13,27 +13,52 @@ def store():
     return value
 
 
+def database_now(value):
+    return value.connection.execute("SELECT unixepoch()").fetchone()[0]
+
+
+def expire(value, resource):
+    expired_at = database_now(value) - 1
+    value.connection.execute(
+        "UPDATE promotion_fences SET expires_at=? WHERE resource=?",
+        (expired_at, resource),
+    )
+    value.connection.execute(
+        "UPDATE promotion_leases SET expires_at=? WHERE resource=?",
+        (expired_at, resource),
+    )
+    value.connection.commit()
+
+
 def test_first_owner_receives_first_fence():
     value = store()
-    assert value.acquire("rc-17", "worker-a", 30, 100) == PromotionLease(
-        "rc-17", "worker-a", 1, 130
-    )
+    before = database_now(value)
+
+    lease = value.acquire("rc-17", "worker-a", 30, 100)
+
+    after = database_now(value)
+    assert lease.resource == "rc-17"
+    assert lease.owner == "worker-a"
+    assert lease.fence == 1
+    assert before + 30 <= lease.expires_at <= after + 30
 
 
 def test_unexpired_lease_blocks_different_owner():
     value = store()
-    value.acquire("rc-17", "worker-a", 30, 100)
-    assert value.acquire("rc-17", "worker-b", 30, 110) is None
+    value.acquire("rc-17", "worker-a", 30, -10_000)
+
+    assert value.acquire("rc-17", "worker-b", 30, 10_000_000_000) is None
 
 
 def test_takeover_increments_fence_and_rejects_stale_publisher():
     value = store()
-    old = value.acquire("rc-17", "worker-a", 30, 100)
-    new = value.acquire("rc-17", "worker-b", 30, 131)
+    old = value.acquire("rc-17", "worker-a", 30, -10_000)
+    expire(value, "rc-17")
+    new = value.acquire("rc-17", "worker-b", 30, 10_000_000_000)
 
     assert new.fence == 2
-    assert value.can_publish("rc-17", old.owner, old.fence, 132) is False
-    assert value.can_publish("rc-17", new.owner, new.fence, 132) is True
+    assert value.can_publish("rc-17", old.owner, old.fence, -10_000) is False
+    assert value.can_publish("rc-17", new.owner, new.fence, 10_000_000_000) is True
 
 
 def test_same_owner_renewal_also_increments_fence():
@@ -44,9 +69,53 @@ def test_same_owner_renewal_also_increments_fence():
     assert second.fence == first.fence + 1
 
 
+def test_acquire_keeps_existing_viewer_row_in_sync():
+    value = store()
+
+    lease = value.acquire("rc-17", "worker-a", 30, 100)
+
+    viewer_row = value.connection.execute(
+        "SELECT resource, owner, expires_at FROM promotion_leases WHERE resource=?",
+        ("rc-17",),
+    ).fetchone()
+    assert viewer_row == (lease.resource, lease.owner, lease.expires_at)
+
+
+def test_initialize_reconciles_existing_viewer_row_from_fence():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE promotion_fences "
+        "(resource TEXT PRIMARY KEY, owner TEXT NOT NULL, "
+        "fence INTEGER NOT NULL, expires_at INTEGER NOT NULL)"
+    )
+    connection.execute(
+        "CREATE TABLE promotion_leases "
+        "(resource TEXT PRIMARY KEY, owner TEXT NOT NULL, expires_at INTEGER NOT NULL)"
+    )
+    connection.execute(
+        "INSERT INTO promotion_fences VALUES ('rc-41', 'worker-b', 18, 200)"
+    )
+    connection.execute(
+        "INSERT INTO promotion_leases VALUES ('rc-41', 'worker-a', 100)"
+    )
+    connection.commit()
+
+    PromotionLeaseStore(connection).initialize()
+
+    assert connection.execute(
+        "SELECT resource, owner, expires_at FROM promotion_leases WHERE resource='rc-41'"
+    ).fetchone() == ("rc-41", "worker-b", 200)
+
+
 def test_failed_takeover_keeps_prior_fence():
     value = store()
-    original = value.acquire("rc-17", "worker-a", 30, 100)
+    value.acquire("rc-17", "worker-a", 30, 100)
+    expire(value, "rc-17")
+    original = value.read("rc-17")
+    viewer_row = value.connection.execute(
+        "SELECT resource, owner, expires_at FROM promotion_leases WHERE resource=?",
+        ("rc-17",),
+    ).fetchone()
     value.connection.execute(
         "CREATE TRIGGER reject_worker_b BEFORE UPDATE ON promotion_fences "
         "WHEN NEW.owner='worker-b' BEGIN SELECT RAISE(ABORT, 'blocked'); END"
@@ -57,3 +126,32 @@ def test_failed_takeover_keeps_prior_fence():
         value.acquire("rc-17", "worker-b", 30, 131)
 
     assert value.read("rc-17") == original
+    assert value.connection.execute(
+        "SELECT resource, owner, expires_at FROM promotion_leases WHERE resource=?",
+        ("rc-17",),
+    ).fetchone() == viewer_row
+
+
+def test_failed_viewer_update_rolls_back_new_fence():
+    value = store()
+    value.acquire("rc-17", "worker-a", 30, 100)
+    expire(value, "rc-17")
+    original = value.read("rc-17")
+    viewer_row = value.connection.execute(
+        "SELECT resource, owner, expires_at FROM promotion_leases WHERE resource=?",
+        ("rc-17",),
+    ).fetchone()
+    value.connection.execute(
+        "CREATE TRIGGER reject_viewer_worker_b BEFORE UPDATE ON promotion_leases "
+        "WHEN NEW.owner='worker-b' BEGIN SELECT RAISE(ABORT, 'viewer blocked'); END"
+    )
+    value.connection.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="viewer blocked"):
+        value.acquire("rc-17", "worker-b", 30, 131)
+
+    assert value.read("rc-17") == original
+    assert value.connection.execute(
+        "SELECT resource, owner, expires_at FROM promotion_leases WHERE resource=?",
+        ("rc-17",),
+    ).fetchone() == viewer_row


### PR DESCRIPTION
## What changed

- use SQLite `unixepoch()` as the authoritative lease clock while retaining the package 5.1 worker-time argument for compatibility
- update `promotion_fences` and the package 4.6 `promotion_leases` viewer row in one immediate transaction, including startup reconciliation
- evaluate owner, fence, and expiry together when a queued callback is revalidated after resume
- cover clock skew, stale callback rejection, viewer synchronization, and rollback when either table write fails

## Why

During rc-41, worker clocks differed by 125 seconds. Worker-a's fence 17 callback resumed after worker-b acquired fence 18, while the live package 4.6 viewer still showed worker-a. The artifact bytes were deduplicated, but both internal status paths advanced and operations held the release for 47 minutes.

## Impact

Promotion takeover decisions no longer depend on worker clock skew, stale callbacks fail the current-fence check, and the live compatibility viewer observes the same owner and expiry as the authoritative fenced row.

## Validation

- `python -m pytest -q tests/test_promotion_lease_models.py tests/test_promotion_lease_store.py` — 9 passed
- `python -m pytest -q` — 155 passed
- `python scripts/verify_repo_baseline.py` — passed
- `git diff origin/main...HEAD --check` — passed

## Tracking and scope

- Linear: [EXP-33](https://linear.app/experttc2/issue/EXP-33/make-promotion-takeover-clock-safe-and-callback-fenced)
- Closes #347

Dashboard history, event retention, metric schema, and runbook follow-ups remain outside this bounded correction because their owners and acceptance criteria are not recorded.