### PR TITLE
Select release artifacts by target platform

### DIFF
--- a/docs/release-artifact-selection.md
+++ b/docs/release-artifact-selection.md
@@ -1,0 +1,4 @@
+# Release artifact selection
+
+Release candidates may publish platform-specific and universal artifacts. The
+selector prefers an exact platform entry and otherwise uses a universal entry.

--- a/src/release_artifact_selector.py
+++ b/src/release_artifact_selector.py
@@ -1,0 +1,11 @@
+"""Release artifact selection for staged deployments."""
+
+
+def select_release_artifact(release_id, platform, candidates):
+    for candidate in candidates:
+        if candidate["platform"] == platform:
+            return candidate
+    for candidate in candidates:
+        if candidate["platform"] == "universal":
+            return candidate
+    raise ValueError(f"no artifact for {release_id} on {platform}")

--- a/tests/test_release_artifact_selector.py
+++ b/tests/test_release_artifact_selector.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.release_artifact_selector import select_release_artifact
+
+
+CANDIDATES = [
+    {"platform": "linux-amd64", "digest": "sha256:amd"},
+    {"platform": "linux-arm64", "digest": "sha256:arm"},
+    {"platform": "universal", "digest": "sha256:any"},
+]
+
+
+def test_selects_exact_platform():
+    assert select_release_artifact("rc-42", "linux-arm64", CANDIDATES)["digest"] == "sha256:arm"
+
+
+def test_uses_universal_fallback():
+    assert select_release_artifact("rc-42", "darwin-arm64", CANDIDATES)["digest"] == "sha256:any"
+
+
+def test_raises_without_match_or_fallback():
+    with pytest.raises(ValueError, match="no artifact"):
+        select_release_artifact("rc-42", "darwin-arm64", CANDIDATES[:2])


### PR DESCRIPTION
Add platform-specific artifact selection with a universal fallback and focused coverage.