### PR TITLE
Cache selected artifacts during a release run

### DIFF
--- a/docs/release-artifact-cache.md
+++ b/docs/release-artifact-cache.md
@@ -1,0 +1,5 @@
+# Artifact selection cache
+
+Selected artifacts are cached during a worker process so repeated deployment
+steps for a release reuse the same candidate object. Release coordination clears
+the cache between release runs.

--- a/src/release_artifact_selector.py
+++ b/src/release_artifact_selector.py
@@ -1,11 +1,21 @@
 """Release artifact selection for staged deployments."""
 
+_selection_cache = {}
+
 
 def select_release_artifact(release_id, platform, candidates):
+    if release_id in _selection_cache:
+        return _selection_cache[release_id]
     for candidate in candidates:
         if candidate["platform"] == platform:
+            _selection_cache[release_id] = candidate
             return candidate
     for candidate in candidates:
         if candidate["platform"] == "universal":
+            _selection_cache[release_id] = candidate
             return candidate
     raise ValueError(f"no artifact for {release_id} on {platform}")
+
+
+def clear_artifact_selection_cache():
+    _selection_cache.clear()

--- a/tests/test_release_artifact_selector.py
+++ b/tests/test_release_artifact_selector.py
@@ -1,6 +1,9 @@
 import pytest
 
-from src.release_artifact_selector import select_release_artifact
+from src.release_artifact_selector import (
+    clear_artifact_selection_cache,
+    select_release_artifact,
+)
 
 
 CANDIDATES = [
@@ -10,8 +13,18 @@ CANDIDATES = [
 ]
 
 
+def setup_function():
+    clear_artifact_selection_cache()
+
+
 def test_selects_exact_platform():
     assert select_release_artifact("rc-42", "linux-arm64", CANDIDATES)["digest"] == "sha256:arm"
+
+
+def test_reuses_selection_for_same_release():
+    first = select_release_artifact("rc-42", "linux-arm64", CANDIDATES)
+    second = select_release_artifact("rc-42", "linux-arm64", list(CANDIDATES))
+    assert second is first
 
 
 def test_uses_universal_fallback():


### PR DESCRIPTION
Reuse the selected candidate across repeated deployment steps for one release and add cache lifecycle coverage.