### PR TITLE
Build release bundle manifests from selected artifacts

### DIFF
--- a/docs/release-bundles.md
+++ b/docs/release-bundles.md
@@ -1,0 +1,4 @@
+# Release bundles
+
+A release bundle maps requested target platforms to the artifact selected for
+each target. Deployment workers reuse the selector cache during bundle assembly.

--- a/src/release_bundle.py
+++ b/src/release_bundle.py
@@ -1,0 +1,8 @@
+from src.release_artifact_selector import select_release_artifact
+
+
+def build_release_bundle(release_id, platforms, candidates):
+    return {
+        platform: select_release_artifact(release_id, platform, candidates)
+        for platform in platforms
+    }

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -1,0 +1,14 @@
+from src.release_artifact_selector import clear_artifact_selection_cache
+from src.release_bundle import build_release_bundle
+
+
+def test_builds_release_bundle_for_requested_platform():
+    clear_artifact_selection_cache()
+    candidates = [
+        {"platform": "linux-amd64", "digest": "sha256:amd"},
+        {"platform": "universal", "digest": "sha256:any"},
+    ]
+
+    assert build_release_bundle("rc-42", ["linux-amd64"], candidates) == {
+        "linux-amd64": {"platform": "linux-amd64", "digest": "sha256:amd"}
+    }


### PR DESCRIPTION
Add a bundle helper that records the artifact chosen for each requested target platform.