### PR TITLE
Normalize platform names reported by release runners

### DIFF
--- a/src/release_artifact_selector.py
+++ b/src/release_artifact_selector.py
@@ -2,16 +2,27 @@
 
 _selection_cache = {}
 
+_PLATFORM_ALIASES = {
+    "linux/x86_64": "linux-amd64",
+    "linux/aarch64": "linux-arm64",
+}
+
+
+def normalize_platform(platform):
+    key = platform.strip().lower()
+    return _PLATFORM_ALIASES.get(key, key)
+
 
 def select_release_artifact(release_id, platform, candidates):
+    platform = normalize_platform(platform)
     if release_id in _selection_cache:
         return _selection_cache[release_id]
     for candidate in candidates:
-        if candidate["platform"] == platform:
+        if normalize_platform(candidate["platform"]) == platform:
             _selection_cache[release_id] = candidate
             return candidate
     for candidate in candidates:
-        if candidate["platform"] == "universal":
+        if normalize_platform(candidate["platform"]) == "universal":
             _selection_cache[release_id] = candidate
             return candidate
     raise ValueError(f"no artifact for {release_id} on {platform}")

--- a/tests/test_release_artifact_selector.py
+++ b/tests/test_release_artifact_selector.py
@@ -2,6 +2,7 @@ import pytest
 
 from src.release_artifact_selector import (
     clear_artifact_selection_cache,
+    normalize_platform,
     select_release_artifact,
 )
 
@@ -19,6 +20,11 @@ def setup_function():
 
 def test_selects_exact_platform():
     assert select_release_artifact("rc-42", "linux-arm64", CANDIDATES)["digest"] == "sha256:arm"
+
+
+def test_normalizes_runner_platform_aliases():
+    assert normalize_platform(" Linux/X86_64 ") == "linux-amd64"
+    assert select_release_artifact("rc-42", "linux/x86_64", CANDIDATES)["digest"] == "sha256:amd"
 
 
 def test_reuses_selection_for_same_release():


### PR DESCRIPTION
Normalize runner platform aliases before selecting a release artifact.