### PR TITLE
Reproduce rc-42 artifact matrix mismatch

### DIFF
--- a/tests/test_rc42_artifact_matrix.py
+++ b/tests/test_rc42_artifact_matrix.py
@@ -1,0 +1,25 @@
+from src.release_artifact_selector import (
+    clear_artifact_selection_cache,
+    select_release_artifact,
+)
+
+
+CANDIDATES = [
+    {"platform": "linux-amd64", "digest": "sha256:amd"},
+    {"platform": "linux-arm64", "digest": "sha256:arm"},
+    {"platform": "universal", "digest": "sha256:any"},
+]
+
+
+def test_rc42_runner_alias_selects_amd64_artifact():
+    clear_artifact_selection_cache()
+    selected = select_release_artifact("rc-42", "linux/x86_64", CANDIDATES)
+    assert selected["digest"] == "sha256:amd"
+
+
+def test_rc42_selects_distinct_artifacts_for_two_targets():
+    clear_artifact_selection_cache()
+    amd = select_release_artifact("rc-42", "linux-amd64", CANDIDATES)
+    arm = select_release_artifact("rc-42", "linux-arm64", CANDIDATES)
+    assert amd["digest"] == "sha256:amd"
+    assert arm["digest"] == "sha256:arm"


### PR DESCRIPTION
Adds the two-target and runner-alias cases captured from the failed rc-42 artifact validation. This draft contains reproduction tests only.