### PR TITLE
Revert release-level artifact selection cache for rc-42

### DIFF
--- a/src/release_artifact_selector.py
+++ b/src/release_artifact_selector.py
@@ -1,21 +1,15 @@
 """Release artifact selection for staged deployments."""
 
-_selection_cache = {}
-
 
 def select_release_artifact(release_id, platform, candidates):
-    if release_id in _selection_cache:
-        return _selection_cache[release_id]
     for candidate in candidates:
         if candidate["platform"] == platform:
-            _selection_cache[release_id] = candidate
             return candidate
     for candidate in candidates:
         if candidate["platform"] == "universal":
-            _selection_cache[release_id] = candidate
             return candidate
     raise ValueError(f"no artifact for {release_id} on {platform}")
 
 
 def clear_artifact_selection_cache():
-    _selection_cache.clear()
+    pass

--- a/tests/test_reverted_artifact_cache.py
+++ b/tests/test_reverted_artifact_cache.py
@@ -1,0 +1,10 @@
+from src.release_artifact_selector import select_release_artifact
+
+
+def test_revert_selects_each_target_independently():
+    candidates = [
+        {"platform": "linux-amd64", "digest": "sha256:amd"},
+        {"platform": "linux-arm64", "digest": "sha256:arm"},
+    ]
+    assert select_release_artifact("rc-42", "linux-amd64", candidates)["digest"] == "sha256:amd"
+    assert select_release_artifact("rc-42", "linux-arm64", candidates)["digest"] == "sha256:arm"


### PR DESCRIPTION
Removes process-level artifact selection reuse from the rc-42 branch and adds a two-target selector check. This draft does not include later main-only changes.