### PR TITLE
Scope cached artifact selection by release and platform

### DIFF
--- a/src/release_artifact_selector.py
+++ b/src/release_artifact_selector.py
@@ -15,15 +15,16 @@ def normalize_platform(platform):
 
 def select_release_artifact(release_id, platform, candidates):
     platform = normalize_platform(platform)
-    if release_id in _selection_cache:
-        return _selection_cache[release_id]
+    cache_key = (release_id, platform)
+    if cache_key in _selection_cache:
+        return _selection_cache[cache_key]
     for candidate in candidates:
         if normalize_platform(candidate["platform"]) == platform:
-            _selection_cache[release_id] = candidate
+            _selection_cache[cache_key] = candidate
             return candidate
     for candidate in candidates:
         if normalize_platform(candidate["platform"]) == "universal":
-            _selection_cache[release_id] = candidate
+            _selection_cache[cache_key] = candidate
             return candidate
     raise ValueError(f"no artifact for {release_id} on {platform}")
 

--- a/tests/test_release_artifact_selector.py
+++ b/tests/test_release_artifact_selector.py
@@ -27,10 +27,17 @@ def test_normalizes_runner_platform_aliases():
     assert select_release_artifact("rc-42", "linux/x86_64", CANDIDATES)["digest"] == "sha256:amd"
 
 
-def test_reuses_selection_for_same_release():
+def test_reuses_selection_for_same_release_and_platform():
     first = select_release_artifact("rc-42", "linux-arm64", CANDIDATES)
-    second = select_release_artifact("rc-42", "linux-arm64", list(CANDIDATES))
+    second = select_release_artifact("rc-42", "linux/aarch64", list(CANDIDATES))
     assert second is first
+
+
+def test_selects_distinct_artifacts_for_two_targets():
+    amd = select_release_artifact("rc-42", "linux-amd64", CANDIDATES)
+    arm = select_release_artifact("rc-42", "linux-arm64", CANDIDATES)
+    assert amd["digest"] == "sha256:amd"
+    assert arm["digest"] == "sha256:arm"
 
 
 def test_uses_universal_fallback():


### PR DESCRIPTION
Changes the selector cache key from release ID to release ID plus normalized platform and adds coverage for repeated multi-target selection and runner aliases.

This branch is based on current `main`. It does not update `release/rc-42` or define which commits should be included in a release recovery.