### PR TITLE
Recover rc-42 artifact selection

### DIFF
--- a/docs/release-artifact-cache.md
+++ b/docs/release-artifact-cache.md
@@ -1,5 +1,16 @@
 # Artifact selection cache
 
-Selected artifacts are cached during a worker process so repeated deployment
-steps for a release reuse the same candidate object. Release coordination clears
-the cache between release runs.
+Selected artifacts are cached during a worker process by release ID and
+normalized target platform. Repeated deployment steps for the same release and
+platform reuse the same candidate object, while different platforms are selected
+independently. Legacy release-only cache entries are ignored after upgrading to
+the platform-scoped selector.
+
+Release coordination owns clearing the cache between release runs. The rc-42
+repository recovery is owned by Fernando Mano in EXP-42.
+
+If a rebuilt manifest does not contain the expected distinct target digests,
+keep promotion held and rc-41 active. Clear the worker cache or use a fresh
+worker before retrying. Do not roll back only the platform-scoped cache key and
+retry rc-42, because the release-only key can reuse one target's artifact for a
+different target.

--- a/docs/release-artifact-selection.md
+++ b/docs/release-artifact-selection.md
@@ -1,4 +1,14 @@
 # Release artifact selection
 
 Release candidates may publish platform-specific and universal artifacts. The
-selector prefers an exact platform entry and otherwise uses a universal entry.
+selector normalizes runner aliases before preferring an exact platform entry and
+otherwise using a universal entry.
+
+The Linux runner aliases used by rc-42 map as follows:
+
+- `linux/x86_64` maps to `linux-amd64`;
+- `linux/aarch64` maps to `linux-arm64`.
+
+Candidate platform values are normalized by the same rules. Selection caching
+is scoped to the release ID plus the normalized platform so a multi-platform
+release cannot reuse an amd64 selection for arm64, or the reverse.

--- a/src/release_artifact_selector.py
+++ b/src/release_artifact_selector.py
@@ -2,17 +2,29 @@
 
 _selection_cache = {}
 
+_PLATFORM_ALIASES = {
+    "linux/x86_64": "linux-amd64",
+    "linux/aarch64": "linux-arm64",
+}
+
+
+def normalize_platform(platform):
+    key = platform.strip().lower()
+    return _PLATFORM_ALIASES.get(key, key)
+
 
 def select_release_artifact(release_id, platform, candidates):
-    if release_id in _selection_cache:
-        return _selection_cache[release_id]
+    platform = normalize_platform(platform)
+    cache_key = (release_id, platform)
+    if cache_key in _selection_cache:
+        return _selection_cache[cache_key]
     for candidate in candidates:
-        if candidate["platform"] == platform:
-            _selection_cache[release_id] = candidate
+        if normalize_platform(candidate["platform"]) == platform:
+            _selection_cache[cache_key] = candidate
             return candidate
     for candidate in candidates:
-        if candidate["platform"] == "universal":
-            _selection_cache[release_id] = candidate
+        if normalize_platform(candidate["platform"]) == "universal":
+            _selection_cache[cache_key] = candidate
             return candidate
     raise ValueError(f"no artifact for {release_id} on {platform}")
 

--- a/tests/test_release_artifact_selector.py
+++ b/tests/test_release_artifact_selector.py
@@ -1,5 +1,6 @@
 import pytest
 
+import src.release_artifact_selector as selector
 from src.release_artifact_selector import (
     clear_artifact_selection_cache,
     select_release_artifact,
@@ -21,10 +22,32 @@ def test_selects_exact_platform():
     assert select_release_artifact("rc-42", "linux-arm64", CANDIDATES)["digest"] == "sha256:arm"
 
 
-def test_reuses_selection_for_same_release():
+def test_normalizes_runner_platform_aliases():
+    assert select_release_artifact("rc-42", "linux/x86_64", CANDIDATES)["digest"] == "sha256:amd"
+    assert select_release_artifact("rc-42", "linux/aarch64", CANDIDATES)["digest"] == "sha256:arm"
+
+
+def test_reuses_selection_for_same_release_and_platform():
     first = select_release_artifact("rc-42", "linux-arm64", CANDIDATES)
-    second = select_release_artifact("rc-42", "linux-arm64", list(CANDIDATES))
+    second = select_release_artifact("rc-42", "linux/aarch64", list(CANDIDATES))
     assert second is first
+
+
+def test_selects_distinct_artifacts_for_two_targets():
+    amd = select_release_artifact("rc-42", "linux-amd64", CANDIDATES)
+    arm = select_release_artifact("rc-42", "linux-arm64", CANDIDATES)
+    assert amd["digest"] == "sha256:amd"
+    assert arm["digest"] == "sha256:arm"
+
+
+def test_legacy_release_only_cache_does_not_poison_target_selection():
+    selector._selection_cache["rc-42"] = CANDIDATES[2]
+
+    amd = select_release_artifact("rc-42", "linux/x86_64", CANDIDATES)
+    arm = select_release_artifact("rc-42", "linux/aarch64", CANDIDATES)
+
+    assert amd["digest"] == "sha256:amd"
+    assert arm["digest"] == "sha256:arm"
 
 
 def test_uses_universal_fallback():


### PR DESCRIPTION
## Decision

Fix forward on `release/rc-42` with the smallest complete delta supported by the rc-42 incident evidence.

- Normalize the observed release-runner aliases to canonical Linux targets.
- Scope cached selection by `(release_id, normalized_platform)`.
- Preserve same-target reuse while preventing an amd64 selection from being reused for arm64.
- Do not include the main-only bundle-manifest caller.

A pointer rollback would not produce an rc-42 artifact for the reserved ARM window. Removing the cache alone does not fix the observed runner aliases, and a main-only fix cannot rebuild rc-42.

## Root cause

The release branch cached selection only by release ID and did not normalize `linux/x86_64` or `linux/aarch64`. The first target fell back to the universal artifact; the second target then reused that cached artifact, producing the duplicate digest that stopped promotion.

## Changes

- backport runner alias normalization;
- key the selection cache by release ID and normalized platform;
- cover both runner aliases, distinct amd64/arm64 selections, same-target reuse, and stale release-only cache state;
- align artifact-selection/cache runbooks with the new behavior, owner, and rollback constraints.

The PR is two commits and four related files ahead of `release/rc-42`.

## Owner and rollback

Fernando Mano owns the repository recovery through [EXP-42](https://linear.app/experttc2/issue/EXP-42/recover-rc-42-with-platform-scoped-artifact-selection). Release coordination owns clearing selector state between release runs and recording rebuilt artifact evidence.

If a rebuilt manifest does not contain distinct expected target digests, keep promotion held and rc-41 active, then clear the worker cache or use a fresh worker before retrying. Do not revert only the platform-scoped cache key and retry rc-42 because that restores the cross-target collision mode.

## Validation

- `python -m pytest tests/test_release_artifact_selector.py -q`: 7 passed;
- `python -m pytest -q`: 162 passed;
- Python 3.12, matching repository CI;
- `git diff --check`: passed;
- [GitHub CI run 408](https://github.com/fermano/TC1/actions/runs/28907476538): succeeded, including `python -m pytest`;
- production-shaped selector check maps `linux/x86_64` to the observed amd64 catalog digest and `linux/aarch64` to the distinct arm64 catalog digest.

## Remaining release gates

The repository recovery is ready for review and merge, but repository validation does not prove release-artifact readiness. No rc-42 artifact has been rebuilt or deployed from this change.

Before promotion resumes:

1. approve and merge this recovery to `release/rc-42`;
2. rebuild rc-42 from an identifiable source commit;
3. verify the rebuilt manifest contains the distinct expected amd64 and arm64 digests;
4. record the artifact ID and manifest digest in release coordination.

EXP-42, incident #356, EXP-38, and EXP-40 must remain open while these gates are unresolved.

Incident evidence: #356