### PR TITLE
Preserve explicit zero retry budgets

### DIFF
--- a/src/attention_retry_budget.py
+++ b/src/attention_retry_budget.py
@@ -1,0 +1,7 @@
+def resolve_attention_retry_budget(requested: int | None, default: int = 3) -> int:
+    """Resolve an explicit retry budget without treating zero as missing."""
+    if requested is None:
+        return default
+    if requested < 0:
+        raise ValueError("retry budget cannot be negative")
+    return requested

--- a/tests/test_attention_retry_budget.py
+++ b/tests/test_attention_retry_budget.py
@@ -1,0 +1,16 @@
+import unittest
+
+from src.attention_retry_budget import resolve_attention_retry_budget
+
+
+class RetryBudgetTests(unittest.TestCase):
+    def test_preserves_explicit_zero(self):
+        self.assertEqual(resolve_attention_retry_budget(0, default=4), 0)
+
+    def test_rejects_negative_values(self):
+        with self.assertRaises(ValueError):
+            resolve_attention_retry_budget(-1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Preserves an explicit retry budget of zero and rejects negative values at the helper boundary. Includes focused unit coverage. Reopened from an older operational patch after branch cleanup; the current configuration contract still needs confirmation.