### PR TITLE
Cache normalized escalation owners

### DIFF
--- a/src/attention_owner_cache.py
+++ b/src/attention_owner_cache.py
@@ -1,0 +1,12 @@
+_owner_cache: dict[str, str] = {}
+
+
+def normalized_owner(owner: str) -> str:
+    key = " ".join(owner.strip().lower().split())
+    if key not in _owner_cache:
+        _owner_cache[key] = key
+    return _owner_cache[key]
+
+
+def clear_owner_cache() -> None:
+    _owner_cache.clear()

--- a/tests/test_attention_owner_cache.py
+++ b/tests/test_attention_owner_cache.py
@@ -1,0 +1,15 @@
+import unittest
+
+from src.attention_owner_cache import clear_owner_cache, normalized_owner
+
+
+class OwnerCacheTests(unittest.TestCase):
+    def setUp(self):
+        clear_owner_cache()
+
+    def test_equivalent_owner_spellings_share_result(self):
+        self.assertEqual(normalized_owner(" Billing   Ops "), normalized_owner("billing ops"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Caches normalized escalation-owner strings to reduce repeated routing work. The cache is process-local and explicitly clearable. A separate older draft approaches the same routing hot path with raw-key memoization.