### PR TITLE
Memoize incident owner resolution

### DIFF
--- a/src/attention_owner_cache.py
+++ b/src/attention_owner_cache.py
@@ -1,0 +1,7 @@
+_owner_cache: dict[str, str] = {}
+
+
+def normalized_owner(owner: str) -> str:
+    if owner not in _owner_cache:
+        _owner_cache[owner] = " ".join(owner.strip().lower().split())
+    return _owner_cache[owner]


### PR DESCRIPTION
Draft restored from a May performance investigation. It memoizes by the raw owner string and has no invalidation hook or focused tests. The newer normalized-key proposal overlaps this code path but preserves different cache semantics.