### PR TITLE
Route blank owners to the default queue

### DIFF
--- a/src/attention_owner_routing.py
+++ b/src/attention_owner_routing.py
@@ -1,0 +1,6 @@
+DEFAULT_QUEUE = "engineering-ops"
+
+
+def route_owner(owner: str | None) -> str:
+    normalized = " ".join((owner or "").strip().lower().split())
+    return normalized or DEFAULT_QUEUE


### PR DESCRIPTION
Normalizes blank and whitespace-only incident owners to the engineering-ops queue. No focused tests are included because the ownership contract is still being reconciled between intake and release operations.