### PR TITLE
Normalize release-channel aliases

### DIFF
--- a/src/attention_release_channel.py
+++ b/src/attention_release_channel.py
@@ -1,0 +1,6 @@
+CHANNEL_ALIASES = {"stable": "ga", "general-availability": "ga"}
+
+
+def normalize_release_channel(channel: str) -> str:
+    key = channel.strip().lower()
+    return CHANNEL_ALIASES.get(key, key)

--- a/tests/test_attention_release_channel.py
+++ b/tests/test_attention_release_channel.py
@@ -1,0 +1,12 @@
+import unittest
+
+from src.attention_release_channel import normalize_release_channel
+
+
+class ReleaseChannelTests(unittest.TestCase):
+    def test_stable_maps_to_ga(self):
+        self.assertEqual(normalize_release_channel(" Stable "), "ga")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Normalizes stable and general-availability to ga. CI coverage is focused, but operational notes disagree on whether stable should map to ga or production for long-lived workers.