### PR TITLE
Remove legacy release-marker fallback

### DIFF
--- a/src/attention_release_marker.py
+++ b/src/attention_release_marker.py
@@ -1,0 +1,6 @@
+def parse_release_marker(value: str) -> tuple[str, str]:
+    """Parse the required channel:version release marker."""
+    channel, separator, version = value.strip().partition(":")
+    if not separator or not channel or not version:
+        raise ValueError("release marker must be channel:version")
+    return channel, version

--- a/tests/test_attention_release_marker.py
+++ b/tests/test_attention_release_marker.py
@@ -1,0 +1,16 @@
+import unittest
+
+from src.attention_release_marker import parse_release_marker
+
+
+class ReleaseMarkerTests(unittest.TestCase):
+    def test_parses_explicit_channel(self):
+        self.assertEqual(parse_release_marker("ga:4.7"), ("ga", "4.7"))
+
+    def test_rejects_omitted_channel(self):
+        with self.assertRaises(ValueError):
+            parse_release_marker("4.7")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Requires channel:version markers and removes the implicit stable-channel fallback. Repository tests pass, but mobile 4.6 rollout evidence still shows omitted-channel markers from one adapter.