### PR TITLE
Document rollback verification ownership

### DIFF
--- a/docs/attention_rollback_ownership.md
+++ b/docs/attention_rollback_ownership.md
@@ -1,0 +1,3 @@
+# Rollback verification ownership
+
+Release operations owns recording the rollback command output. The service owner confirms the restored version and links the repository commit. No production action is performed by this documentation change.


### PR DESCRIPTION
Clarifies the existing rollback checklist ownership split. Documentation-only; no behavior or required check changes. The checklist link and owner names have already been verified.