### PR TITLE
Stabilize handoff summary ordering

### DIFF
--- a/src/attention_handoff_order.py
+++ b/src/attention_handoff_order.py
@@ -1,0 +1,5 @@
+SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+def order_handoff_rows(rows: list[dict]) -> list[dict]:
+    return sorted(rows, key=lambda row: (SEVERITY_ORDER.get(row.get("severity"), 9), row.get("owner", "")))

--- a/tests/test_attention_handoff_order.py
+++ b/tests/test_attention_handoff_order.py
@@ -1,0 +1,17 @@
+import unittest
+
+from src.attention_handoff_order import order_handoff_rows
+
+
+class HandoffOrderTests(unittest.TestCase):
+    def test_orders_severity_then_named_owner(self):
+        rows = [
+            {"severity": "high", "owner": "zeta"},
+            {"severity": "critical", "owner": "beta"},
+            {"severity": "high", "owner": "alpha"},
+        ]
+        self.assertEqual([row["owner"] for row in order_handoff_rows(rows)], ["beta", "alpha", "zeta"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Orders handoff rows by severity and owner for deterministic summaries. Named-owner coverage passes; operational samples also contain null owners, whose intended placement is not documented.