### PR TITLE
Prototype delivery owner filtering

### DIFF
--- a/src/ticket_workflow_filter_prototype.py
+++ b/src/ticket_workflow_filter_prototype.py
@@ -1,0 +1,9 @@
+from src.ticket_workflow_seed import normalize_delivery_owner
+
+
+def filter_delivery_records(records: list[dict], owners: list[str] | None) -> list[dict]:
+    if owners is None:
+        return list(records)
+    selected = {normalize_delivery_owner(owner) for owner in owners}
+    matching = [record for record in records if normalize_delivery_owner(record.get("owner")) in selected]
+    return sorted(matching, key=lambda record: normalize_delivery_owner(record.get("owner")))


### PR DESCRIPTION
Prototype associated with https://github.com/fermano/TC1/issues/374. It normalizes selected owners and distinguishes None from an empty list, but it sorts matching records and therefore may not preserve source order.