### PR TITLE
EXP-131 Canonicalize delivery owner whitespace

### DIFF
--- a/docs/ticket-workflow-contract.md
+++ b/docs/ticket-workflow-contract.md
@@ -1,6 +1,6 @@
 # Delivery workflow contract
 
-Delivery owner keys are trimmed and lowercased. Blank owners use `engineering-ops`.
+Delivery owner keys are trimmed, lowercased, and collapse runs of Unicode whitespace to a single ASCII space. Punctuation and separators are preserved. Blank owners use `engineering-ops`.
 
 Future record filters must preserve the input record order. A missing owner selection means no filtering. The product meaning of an explicitly empty selection is not yet recorded here.
 

--- a/src/ticket_workflow_seed.py
+++ b/src/ticket_workflow_seed.py
@@ -3,7 +3,7 @@ DEFAULT_OWNER = "engineering-ops"
 
 def normalize_delivery_owner(owner: str | None) -> str:
     """Return the routing key used by delivery workflows."""
-    normalized = (owner or "").strip().lower()
+    normalized = " ".join((owner or "").split()).lower()
     return normalized or DEFAULT_OWNER
 
 

--- a/tests/test_ticket_workflow_seed.py
+++ b/tests/test_ticket_workflow_seed.py
@@ -10,6 +10,15 @@ class TicketWorkflowSeedTests(unittest.TestCase):
     def test_owner_is_trimmed_and_lowercased(self):
         self.assertEqual(normalize_delivery_owner(" Billing-Ops "), "billing-ops")
 
+    def test_owner_collapses_repeated_unicode_whitespace(self):
+        self.assertEqual(
+            normalize_delivery_owner("  Billing\t\u2003Ops\n"),
+            "billing ops",
+        )
+
+    def test_owner_preserves_punctuation(self):
+        self.assertEqual(normalize_delivery_owner("Billing/OnCall"), "billing/oncall")
+
     def test_summary_contains_existing_fields(self):
         self.assertEqual(
             delivery_summary({"owner": " Billing-Ops ", "status": "queued"}),


### PR DESCRIPTION
## What changed

- collapse runs of Unicode whitespace during delivery owner normalization
- preserve punctuation, lowercase behavior, and the blank-owner fallback
- add focused regression coverage and update the delivery contract

## Why

CSV imports could produce multiple routing keys for the same logical owner when whitespace differed.

Linear: https://linear.app/experttc2/issue/EXP-131/canonicalize-unicode-whitespace-in-delivery-owners

## Validation

- `python -m pytest -q`: 166 passed
- `git diff --check`: passed
