### PR TITLE
EXP-132 Filter delivery records by canonical owner

### DIFF
--- a/docs/ticket-workflow-contract.md
+++ b/docs/ticket-workflow-contract.md
@@ -2,6 +2,6 @@
 
 Delivery owner keys are trimmed, lowercased, and collapse runs of Unicode whitespace to a single ASCII space. Punctuation and separators are preserved. Blank owners use `engineering-ops`.
 
-Future record filters must preserve the input record order. A missing owner selection means no filtering. The product meaning of an explicitly empty selection is not yet recorded here.
+Owner filtering uses the same canonical keys and preserves input record order. A missing owner selection (`owners=None`) means no filtering. An explicitly empty selection (`owners=[]`) returns no records. Duplicate selections never duplicate records.
 
 Delivery summaries expose owner and status. Source metadata may be added as an opt-in field; behavior for blank or missing source values is not yet recorded here.

--- a/src/ticket_workflow_seed.py
+++ b/src/ticket_workflow_seed.py
@@ -7,6 +7,19 @@ def normalize_delivery_owner(owner: str | None) -> str:
     return normalized or DEFAULT_OWNER
 
 
+def filter_delivery_records(records: list[dict], owners: list[str] | None = None) -> list[dict]:
+    """Return records whose canonical owner is explicitly selected."""
+    if owners is None:
+        return list(records)
+
+    selected_owners = {normalize_delivery_owner(owner) for owner in owners}
+    return [
+        record
+        for record in records
+        if normalize_delivery_owner(record.get("owner")) in selected_owners
+    ]
+
+
 def delivery_summary(record: dict) -> dict:
     """Return the stable summary fields currently exposed to callers."""
     return {

--- a/src/ticket_workflow_seed.py
+++ b/src/ticket_workflow_seed.py
@@ -7,7 +7,9 @@ def normalize_delivery_owner(owner: str | None) -> str:
     return normalized or DEFAULT_OWNER
 
 
-def filter_delivery_records(records: list[dict], owners: list[str] | None = None) -> list[dict]:
+def filter_delivery_records(
+    records: list[dict], owners: list[str | None] | None = None
+) -> list[dict]:
     """Return records whose canonical owner is explicitly selected."""
     if owners is None:
         return list(records)

--- a/tests/test_ticket_workflow_seed.py
+++ b/tests/test_ticket_workflow_seed.py
@@ -1,6 +1,11 @@
 import unittest
 
-from src.ticket_workflow_seed import DEFAULT_OWNER, delivery_summary, normalize_delivery_owner
+from src.ticket_workflow_seed import (
+    DEFAULT_OWNER,
+    delivery_summary,
+    filter_delivery_records,
+    normalize_delivery_owner,
+)
 
 
 class TicketWorkflowSeedTests(unittest.TestCase):
@@ -18,6 +23,29 @@ class TicketWorkflowSeedTests(unittest.TestCase):
 
     def test_owner_preserves_punctuation(self):
         self.assertEqual(normalize_delivery_owner("Billing/OnCall"), "billing/oncall")
+
+    def test_missing_owner_filter_returns_all_records(self):
+        records = [{"owner": "alpha"}, {"owner": "beta"}]
+        self.assertEqual(filter_delivery_records(records), records)
+
+    def test_empty_owner_filter_returns_no_records(self):
+        self.assertEqual(filter_delivery_records([{"owner": "alpha"}], []), [])
+
+    def test_owner_filter_canonicalizes_deduplicates_and_preserves_order(self):
+        records = [
+            {"id": 1, "owner": "Beta Ops"},
+            {"id": 2, "owner": "alpha"},
+            {"id": 3, "owner": " beta\t ops "},
+            {"id": 4, "owner": "gamma"},
+        ]
+        self.assertEqual(
+            filter_delivery_records(records, [" BETA OPS ", "beta\u2003ops"]),
+            [records[0], records[2]],
+        )
+
+    def test_owner_filter_matches_blank_owner_to_default(self):
+        records = [{"owner": None}, {"owner": "alpha"}]
+        self.assertEqual(filter_delivery_records(records, [DEFAULT_OWNER]), [records[0]])
 
     def test_summary_contains_existing_fields(self):
         self.assertEqual(

--- a/tests/test_ticket_workflow_seed.py
+++ b/tests/test_ticket_workflow_seed.py
@@ -43,9 +43,9 @@ class TicketWorkflowSeedTests(unittest.TestCase):
             [records[0], records[2]],
         )
 
-    def test_owner_filter_matches_blank_owner_to_default(self):
+    def test_blank_owner_selection_matches_blank_record_through_default(self):
         records = [{"owner": None}, {"owner": "alpha"}]
-        self.assertEqual(filter_delivery_records(records, [DEFAULT_OWNER]), [records[0]])
+        self.assertEqual(filter_delivery_records(records, [None]), [records[0]])
 
     def test_summary_contains_existing_fields(self):
         self.assertEqual(


### PR DESCRIPTION
## What changed

- add an order-preserving backend owner filter
- reuse canonical routing keys for records and selections
- distinguish no filter from an explicit empty selection
- document and test deduplication, fallback matching, and ordering

Linear: https://linear.app/experttc2/issue/EXP-132/filter-delivery-records-by-canonical-owner

## Validation

- `python -m pytest -q`: 170 passed
- `git diff --check`: passed
