### PR TITLE
EXP-133 Add opt-in source metadata to delivery summaries

### DIFF
--- a/docs/ticket-workflow-contract.md
+++ b/docs/ticket-workflow-contract.md
@@ -4,4 +4,4 @@ Delivery owner keys are trimmed, lowercased, and collapse runs of Unicode whites
 
 Owner filtering uses the same canonical keys and preserves input record order. A missing owner selection (`owners=None`) means no filtering. An explicitly empty selection (`owners=[]`) returns no records. Duplicate selections never duplicate records.
 
-Delivery summaries expose owner and status. Source metadata may be added as an opt-in field; behavior for blank or missing source values is not yet recorded here.
+Delivery summaries expose owner and status by default. With `include_source=True`, a present source is trimmed and included; missing, empty, and whitespace-only sources are omitted.

--- a/src/ticket_workflow_seed.py
+++ b/src/ticket_workflow_seed.py
@@ -22,9 +22,13 @@ def filter_delivery_records(
     ]
 
 
-def delivery_summary(record: dict) -> dict:
+def delivery_summary(record: dict, include_source: bool = False) -> dict:
     """Return the stable summary fields currently exposed to callers."""
-    return {
+    summary = {
         "owner": normalize_delivery_owner(record.get("owner")),
         "status": record["status"],
     }
+    source = (record.get("source") or "").strip()
+    if include_source and source:
+        summary["source"] = source
+    return summary

--- a/tests/test_ticket_workflow_seed.py
+++ b/tests/test_ticket_workflow_seed.py
@@ -49,9 +49,32 @@ class TicketWorkflowSeedTests(unittest.TestCase):
 
     def test_summary_contains_existing_fields(self):
         self.assertEqual(
-            delivery_summary({"owner": " Billing-Ops ", "status": "queued"}),
+            delivery_summary(
+                {"owner": " Billing-Ops ", "status": "queued", "source": "api"}
+            ),
             {"owner": "billing-ops", "status": "queued"},
         )
+
+    def test_summary_includes_trimmed_source_when_opted_in(self):
+        self.assertEqual(
+            delivery_summary(
+                {"owner": "alpha", "status": "queued", "source": "  api  "},
+                include_source=True,
+            ),
+            {"owner": "alpha", "status": "queued", "source": "api"},
+        )
+
+    def test_summary_omits_blank_or_missing_source_when_opted_in(self):
+        for record in (
+            {"owner": "alpha", "status": "queued"},
+            {"owner": "alpha", "status": "queued", "source": "   "},
+            {"owner": "alpha", "status": "queued", "source": None},
+        ):
+            with self.subTest(record=record):
+                self.assertEqual(
+                    delivery_summary(record, include_source=True),
+                    {"owner": "alpha", "status": "queued"},
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- add a backward-compatible `include_source` option
- include only trimmed, nonblank source values
- preserve the default owner-and-status response shape
- document and test the opt-in contract

Linear: https://linear.app/experttc2/issue/EXP-133/add-opt-in-source-metadata-to-delivery-summaries

## Validation

- `python -m pytest -q`: 172 passed, 3 subtests passed
- `git diff --check`: passed
