### PR TITLE
Add stable delivery owner filtering

### DIFF
--- a/src/delivery_owner_filter.py
+++ b/src/delivery_owner_filter.py
@@ -1,0 +1,8 @@
+from src.ticket_workflow_seed import normalize_delivery_owner
+
+
+def filter_delivery_records(records: list[dict], owners: list[str] | None) -> list[dict]:
+    if owners is None:
+        return list(records)
+    selected = {normalize_delivery_owner(owner) for owner in owners}
+    return [record for record in records if normalize_delivery_owner(record.get("owner")) in selected]

--- a/tests/test_delivery_owner_filter.py
+++ b/tests/test_delivery_owner_filter.py
@@ -1,0 +1,10 @@
+import unittest
+from src.delivery_owner_filter import filter_delivery_records
+class OwnerFilterTests(unittest.TestCase):
+    def setUp(self):
+        self.rows=[{"id":1,"owner":"Billing  Ops"},{"id":2,"owner":"sales"},{"id":3,"owner":"billing ops"}]
+    def test_none_means_no_filter(self): self.assertEqual(filter_delivery_records(self.rows,None),self.rows)
+    def test_empty_means_no_records(self): self.assertEqual(filter_delivery_records(self.rows,[]),[])
+    def test_normalized_matching_preserves_order_once(self):
+        self.assertEqual([r["id"] for r in filter_delivery_records(self.rows,["billing ops"," Billing  Ops "])],[1,3])
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
Adds normalized owner filtering with explicit None versus empty-list semantics, deduplicated selections, and preserved input order. Supersedes the closed sorting prototype.