### PR TITLE
Add opt-in source metadata to delivery summaries

### DIFF
--- a/src/delivery_summary_metadata.py
+++ b/src/delivery_summary_metadata.py
@@ -1,0 +1,9 @@
+from src.ticket_workflow_seed import delivery_summary
+
+
+def delivery_summary_with_source(record: dict, include_source: bool = False) -> dict:
+    result = delivery_summary(record)
+    source = record.get("source")
+    if include_source and isinstance(source, str) and source.strip():
+        result["source"] = source.strip()
+    return result

--- a/tests/test_delivery_summary_metadata.py
+++ b/tests/test_delivery_summary_metadata.py
@@ -1,0 +1,10 @@
+import unittest
+from src.delivery_summary_metadata import delivery_summary_with_source
+class SummarySourceTests(unittest.TestCase):
+    def test_default_shape_is_unchanged(self):
+        self.assertEqual(delivery_summary_with_source({"owner":"ops","status":"sent","source":" api "}),{"owner":"ops","status":"sent"})
+    def test_opt_in_trims_source(self):
+        self.assertEqual(delivery_summary_with_source({"owner":"ops","status":"sent","source":" api "},True)["source"],"api")
+    def test_opt_in_omits_blank_source(self):
+        self.assertNotIn("source",delivery_summary_with_source({"owner":"ops","status":"sent","source":"  "},True))
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
Adds backwards-compatible source metadata for delivery summaries. Default output remains unchanged; opted-in blank or missing values are omitted.