### PR TITLE
Deduplicate delivery retries within a worker

### DIFF
--- a/src/delivery_dedupe_cursor.py
+++ b/src/delivery_dedupe_cursor.py
@@ -1,0 +1,9 @@
+class DeliveryDeduper:
+    def __init__(self) -> None:
+        self._seen: set[str] = set()
+
+    def accept(self, delivery_id: str) -> bool:
+        if delivery_id in self._seen:
+            return False
+        self._seen.add(delivery_id)
+        return True

--- a/tests/test_delivery_dedupe_cursor.py
+++ b/tests/test_delivery_dedupe_cursor.py
@@ -1,0 +1,8 @@
+import unittest
+from src.delivery_dedupe_cursor import DeliveryDeduper
+class DedupeTests(unittest.TestCase):
+    def test_rejects_retry_in_same_worker(self):
+        d=DeliveryDeduper(); self.assertTrue(d.accept("del-1")); self.assertFalse(d.accept("del-1"))
+    def test_accepts_distinct_delivery(self):
+        d=DeliveryDeduper(); self.assertTrue(d.accept("del-1")); self.assertTrue(d.accept("del-2"))
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
Adds a process-local delivery ID cursor that rejects repeated deliveries handled by the same worker. Focused tests cover retries and distinct IDs.