### PR TITLE
Require canonical delivery queue names

### DIFF
--- a/src/delivery_queue_names.py
+++ b/src/delivery_queue_names.py
@@ -1,0 +1,8 @@
+CANONICAL_QUEUES = {"engineering-ops", "billing-ops", "release-ops"}
+
+
+def canonical_delivery_queue(queue: str) -> str:
+    normalized = queue.strip().lower()
+    if normalized not in CANONICAL_QUEUES:
+        raise ValueError(f"unknown delivery queue: {queue}")
+    return normalized

--- a/tests/test_delivery_queue_names.py
+++ b/tests/test_delivery_queue_names.py
@@ -1,0 +1,7 @@
+import unittest
+from src.delivery_queue_names import canonical_delivery_queue
+class QueueNameTests(unittest.TestCase):
+    def test_accepts_canonical_queue(self): self.assertEqual(canonical_delivery_queue(" Billing-Ops "),"billing-ops")
+    def test_rejects_legacy_general_alias(self):
+        with self.assertRaises(ValueError): canonical_delivery_queue("general")
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
Rejects legacy queue aliases and accepts only canonical delivery queue names. Tests cover canonical normalization and the former general alias.