### PR TITLE
Bound delivery batch submissions

### DIFF
--- a/src/delivery_batch_limits.py
+++ b/src/delivery_batch_limits.py
@@ -1,0 +1,7 @@
+MAX_DELIVERY_BATCH = 100
+
+
+def validate_delivery_batch(records: list[dict]) -> list[dict]:
+    if len(records) > MAX_DELIVERY_BATCH:
+        raise ValueError(f"delivery batch exceeds {MAX_DELIVERY_BATCH} records")
+    return records

--- a/tests/test_delivery_batch_limits.py
+++ b/tests/test_delivery_batch_limits.py
@@ -1,0 +1,7 @@
+import unittest
+from src.delivery_batch_limits import MAX_DELIVERY_BATCH, validate_delivery_batch
+class BatchLimitTests(unittest.TestCase):
+    def test_accepts_maximum_batch(self): self.assertEqual(len(validate_delivery_batch([{}]*MAX_DELIVERY_BATCH)),MAX_DELIVERY_BATCH)
+    def test_rejects_oversized_batch(self):
+        with self.assertRaises(ValueError): validate_delivery_batch([{}]*(MAX_DELIVERY_BATCH+1))
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
Rejects delivery batches above 100 records and covers the exact boundary. API callers are documented as responsible for chunking larger submissions.