### PR TITLE
Preserve configured delivery lease grace

### DIFF
--- a/src/review_seed_lease_grace.py
+++ b/src/review_seed_lease_grace.py
@@ -1,0 +1,8 @@
+"""Lease-grace parsing proposed for the delivery worker."""
+
+DEFAULT_LEASE_GRACE_SECONDS = 30
+
+
+def effective_lease_grace(configured_seconds, default_seconds=DEFAULT_LEASE_GRACE_SECONDS):
+    """Return the configured grace period or the workspace default."""
+    return configured_seconds or default_seconds

--- a/tests/test_review_seed_lease_grace.py
+++ b/tests/test_review_seed_lease_grace.py
@@ -1,0 +1,18 @@
+import unittest
+
+from src.review_seed_lease_grace import (
+    DEFAULT_LEASE_GRACE_SECONDS,
+    effective_lease_grace,
+)
+
+
+class LeaseGraceTests(unittest.TestCase):
+    def test_missing_value_uses_default(self):
+        self.assertEqual(effective_lease_grace(None), DEFAULT_LEASE_GRACE_SECONDS)
+
+    def test_positive_override_is_preserved(self):
+        self.assertEqual(effective_lease_grace(12), 12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a small helper for selecting a configured delivery lease grace or the workspace default.

The branch currently follows the existing truthy-fallback convention. Review is requested on whether explicit zero has distinct operational meaning.

Validation: repository CI.