### PR TITLE
Honor Retry-After on throttled delivery handoffs

### DIFF
--- a/src/review_seed_retry_after.py
+++ b/src/review_seed_retry_after.py
@@ -1,0 +1,8 @@
+"""Retry-After parsing for delivery handoffs."""
+
+
+def parse_retry_after(value, now_epoch=None):
+    """Return a non-negative delay in seconds for a numeric Retry-After value."""
+    if value is None or not value.strip():
+        return None
+    return max(0, int(value.strip()))

--- a/tests/test_review_seed_retry_after.py
+++ b/tests/test_review_seed_retry_after.py
@@ -1,0 +1,18 @@
+import unittest
+
+from src.review_seed_retry_after import parse_retry_after
+
+
+class RetryAfterTests(unittest.TestCase):
+    def test_numeric_delay(self):
+        self.assertEqual(parse_retry_after("120"), 120)
+
+    def test_http_date_delay(self):
+        self.assertEqual(
+            parse_retry_after("Thu, 16 Jul 2026 20:00:10 GMT", now_epoch=1784232000),
+            10,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Retry-After parsing for delivery retries. Numeric delay values are supported and clamped to non-negative seconds.

A compatibility test also records the HTTP-date form observed from one upstream gateway; that case is not yet implemented.

Validation: repository CI, including the new Retry-After tests.