### PR TITLE
Clarify canonical delivery queue names

### DIFF
--- a/docs/delivery-queue-names.md
+++ b/docs/delivery-queue-names.md
@@ -1,0 +1,5 @@
+# Delivery queue names
+
+Delivery submissions use the canonical queue names `priority`, `standard`, and `bulk`.
+
+The legacy `general` value is not accepted by the current ingestion API. Older mobile adapters must migrate to `standard`; this document does not introduce a compatibility alias.


### PR DESCRIPTION
Documents the three canonical ingestion queue names and the migration expectation for the retired `general` value.

The wording was revised after early review to distinguish documentation from a compatibility implementation.

Validation: documentation-only diff and repository CI.