### PR TITLE
Normalize shorthand delivery regions

### DIFF
--- a/src/review_seed_region_aliases.py
+++ b/src/review_seed_region_aliases.py
@@ -1,0 +1,12 @@
+"""Canonical aliases accepted by delivery-region selection."""
+
+REGION_ALIASES = {
+    "eu": "eu-west-1",
+    "europe": "eu-west-1",
+    "us": "us-east-1",
+}
+
+
+def normalize_delivery_region(value):
+    normalized = value.strip().lower()
+    return REGION_ALIASES.get(normalized, normalized)


### PR DESCRIPTION
Normalizes the supported `eu`, `europe`, and `us` delivery-region shorthands while preserving already-canonical or unknown values.

Review discussion is expected to confirm whether the special `global` coordinator value should remain pass-through.

Validation: repository CI.