### PR TITLE
Add delivery attempt outcome metrics

### DIFF
--- a/src/review_seed_delivery_metrics.py
+++ b/src/review_seed_delivery_metrics.py
@@ -5,5 +5,4 @@ def delivery_attempt_labels(record):
     return {
         "queue": record["queue"],
         "outcome": record["outcome"],
-        "delivery_id": record["delivery_id"],
     }

--- a/src/review_seed_delivery_metrics.py
+++ b/src/review_seed_delivery_metrics.py
@@ -1,0 +1,9 @@
+"""Metric labels for delivery attempts."""
+
+
+def delivery_attempt_labels(record):
+    return {
+        "queue": record["queue"],
+        "outcome": record["outcome"],
+        "delivery_id": record["delivery_id"],
+    }

--- a/tests/test_review_seed_delivery_metrics.py
+++ b/tests/test_review_seed_delivery_metrics.py
@@ -1,0 +1,26 @@
+import unittest
+
+from src.review_seed_delivery_metrics import delivery_attempt_labels
+
+
+class DeliveryAttemptLabelTests(unittest.TestCase):
+    def test_returns_only_bounded_labels(self):
+        record = {
+            "queue": "priority",
+            "outcome": "retried",
+            "delivery_id": "delivery-928173",
+        }
+        self.assertEqual(
+            delivery_attempt_labels(record),
+            {"queue": "priority", "outcome": "retried"},
+        )
+
+    def test_does_not_mutate_input(self):
+        record = {"queue": "bulk", "outcome": "sent", "delivery_id": "d-1"}
+        before = dict(record)
+        delivery_attempt_labels(record)
+        self.assertEqual(record, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds structured labels for delivery-attempt metrics to support queue-level outcome monitoring.

The initial revision includes queue, outcome, and delivery identifier labels. Review is requested on label cardinality.

Validation: repository CI.