### PR TITLE
Accept rotated webhook signing keys

### DIFF
--- a/src/coverage_seed_signatures.py
+++ b/src/coverage_seed_signatures.py
@@ -1,0 +1,16 @@
+"""Webhook signature verification with rotation support."""
+
+import hashlib
+import hmac
+
+
+def _digest(payload, key):
+    return hmac.new(key.encode(), payload, hashlib.sha256).hexdigest()
+
+
+def verify_webhook_signature(payload, signature, primary_key, fallback_key=None):
+    if hmac.compare_digest(_digest(payload, primary_key), signature):
+        return True
+    if fallback_key is not None:
+        return hmac.compare_digest(_digest(payload, fallback_key), signature)
+    return False

--- a/tests/test_coverage_seed_signatures.py
+++ b/tests/test_coverage_seed_signatures.py
@@ -1,0 +1,19 @@
+import hashlib
+import hmac
+import unittest
+
+from src.coverage_seed_signatures import verify_webhook_signature
+
+
+class WebhookSignatureTests(unittest.TestCase):
+    def test_primary_key_accepts_valid_signature(self):
+        payload = b"{\"delivery\": 41}"
+        signature = hmac.new(b"primary", payload, hashlib.sha256).hexdigest()
+        self.assertTrue(verify_webhook_signature(payload, signature, "primary"))
+
+    def test_primary_key_rejects_invalid_signature(self):
+        self.assertFalse(verify_webhook_signature(b"payload", "invalid", "primary"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Allows webhook verification to accept either the current signing key or an optional rotation fallback.

Focused tests cover current-key acceptance and invalid signatures. Rotation-window coverage is still under review.

Validation: repository CI.