### PR TITLE
Extract delivery outcome categorization

### DIFF
--- a/src/coverage_seed_outcomes.py
+++ b/src/coverage_seed_outcomes.py
@@ -1,0 +1,16 @@
+"""Shared delivery-outcome categorization."""
+
+SUCCESS_OUTCOMES = {"sent", "delivered"}
+RETRY_OUTCOMES = {"retry", "rate_limited"}
+DROP_OUTCOMES = {"rejected", "expired"}
+
+
+def categorize_delivery_outcome(value):
+    normalized = (value or "").strip().lower()
+    if normalized in SUCCESS_OUTCOMES:
+        return "success"
+    if normalized in RETRY_OUTCOMES:
+        return "retry"
+    if normalized in DROP_OUTCOMES:
+        return "dropped"
+    return "unknown"

--- a/tests/test_coverage_seed_outcomes.py
+++ b/tests/test_coverage_seed_outcomes.py
@@ -1,0 +1,30 @@
+import unittest
+
+from src.coverage_seed_outcomes import categorize_delivery_outcome
+
+
+class DeliveryOutcomeTests(unittest.TestCase):
+    def test_all_declared_outcomes(self):
+        cases = {
+            "sent": "success",
+            "delivered": "success",
+            "retry": "retry",
+            "rate_limited": "retry",
+            "rejected": "dropped",
+            "expired": "dropped",
+        }
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(categorize_delivery_outcome(value), expected)
+
+    def test_normalizes_case_and_whitespace(self):
+        self.assertEqual(categorize_delivery_outcome("  SENT "), "success")
+
+    def test_unknown_empty_and_none(self):
+        for value in ("other", "", None):
+            with self.subTest(value=value):
+                self.assertEqual(categorize_delivery_outcome(value), "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extracts delivery outcome categorization into a shared helper without changing the declared categories.

Table-driven tests cover every declared value, normalization, unknown input, empty input, and null input.

Validation: repository CI.