### PR TITLE
Add opt-in tenant metadata to audit records

### DIFF
--- a/src/coverage_seed_audit_projection.py
+++ b/src/coverage_seed_audit_projection.py
@@ -1,0 +1,8 @@
+"""Audit-record projection with opt-in tenant metadata."""
+
+
+def project_audit_record(event, include_tenant=False):
+    projected = {"id": event["id"], "action": event["action"]}
+    if include_tenant and event.get("tenant_id"):
+        projected["tenant_id"] = event["tenant_id"].strip()
+    return projected

--- a/tests/test_coverage_seed_audit_projection.py
+++ b/tests/test_coverage_seed_audit_projection.py
@@ -11,6 +11,20 @@ class AuditProjectionTests(unittest.TestCase):
             {"id": "evt-1", "action": "sent", "tenant_id": "tenant-7"},
         )
 
+    def test_default_preserves_existing_shape(self):
+        event = {"id": "evt-2", "action": "retried", "tenant_id": "tenant-8"}
+        self.assertEqual(
+            project_audit_record(event),
+            {"id": "evt-2", "action": "retried"},
+        )
+
+    def test_opt_in_omits_missing_tenant(self):
+        event = {"id": "evt-3", "action": "sent"}
+        self.assertEqual(
+            project_audit_record(event, include_tenant=True),
+            {"id": "evt-3", "action": "sent"},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_coverage_seed_audit_projection.py
+++ b/tests/test_coverage_seed_audit_projection.py
@@ -1,0 +1,16 @@
+import unittest
+
+from src.coverage_seed_audit_projection import project_audit_record
+
+
+class AuditProjectionTests(unittest.TestCase):
+    def test_opt_in_includes_trimmed_tenant(self):
+        event = {"id": "evt-1", "action": "sent", "tenant_id": " tenant-7 "}
+        self.assertEqual(
+            project_audit_record(event, include_tenant=True),
+            {"id": "evt-1", "action": "sent", "tenant_id": "tenant-7"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds optional tenant metadata to projected audit records while intending to preserve the default record shape.

The initial focused test covers the opt-in path. Default compatibility coverage is under review.

Validation: repository CI.