### PR TITLE
Prototype offset cursors for audit exports

### DIFF
--- a/src/seed_audit_offset_cursor.py
+++ b/src/seed_audit_offset_cursor.py
@@ -1,0 +1,8 @@
+"""Offset-based audit export prototype."""
+
+
+def page_from_offset(records, offset=0, limit=100):
+    ordered = sorted(records, key=lambda item: (item["occurred_at"], item["id"]))
+    page = ordered[offset : offset + limit]
+    next_offset = offset + len(page)
+    return page, str(next_offset)

--- a/tests/test_seed_audit_offset_cursor.py
+++ b/tests/test_seed_audit_offset_cursor.py
@@ -1,0 +1,19 @@
+import unittest
+
+from src.seed_audit_offset_cursor import page_from_offset
+
+
+class OffsetCursorTests(unittest.TestCase):
+    def test_static_pages_do_not_repeat_or_omit(self):
+        records = [
+            {"id": "evt-a", "occurred_at": 100},
+            {"id": "evt-b", "occurred_at": 100},
+            {"id": "evt-c", "occurred_at": 101},
+        ]
+        first, cursor = page_from_offset(records, limit=1)
+        second, _ = page_from_offset(records, offset=int(cursor), limit=2)
+        self.assertEqual([item["id"] for item in first + second], ["evt-a", "evt-b", "evt-c"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Explores offset-based pagination to avoid dropping same-timestamp events in static exports. Includes a focused static-page test.

This does not yet establish behavior when records are inserted between pages or compatibility with persisted decimal timestamp cursors.

Related: #398