### PR TITLE
Prototype timestamp-and-ID audit cursors

### DIFF
--- a/src/seed_audit_composite_cursor.py
+++ b/src/seed_audit_composite_cursor.py
@@ -1,0 +1,20 @@
+"""Composite audit cursor prototype."""
+
+
+def encode_composite_cursor(record):
+    return f"v2:{record['occurred_at']}:{record['id']}"
+
+
+def decode_composite_cursor(cursor):
+    if cursor.startswith("v2:"):
+        _, timestamp, record_id = cursor.split(":", 2)
+        return int(timestamp), record_id
+    return int(cursor), "\uffff"
+
+
+def page_after_composite_cursor(records, cursor=None, limit=100):
+    ordered = sorted(records, key=lambda item: (item["occurred_at"], item["id"]))
+    if cursor is not None:
+        boundary = decode_composite_cursor(cursor)
+        ordered = [item for item in ordered if (item["occurred_at"], item["id"]) > boundary]
+    return ordered[:limit]

--- a/tests/test_seed_audit_composite_cursor.py
+++ b/tests/test_seed_audit_composite_cursor.py
@@ -1,0 +1,33 @@
+import unittest
+
+from src.seed_audit_composite_cursor import (
+    encode_composite_cursor,
+    page_after_composite_cursor,
+)
+
+
+class CompositeCursorTests(unittest.TestCase):
+    def test_resume_inside_same_timestamp_group(self):
+        records = [
+            {"id": "evt-a", "occurred_at": 100},
+            {"id": "evt-b", "occurred_at": 100},
+        ]
+        cursor = encode_composite_cursor(records[0])
+        self.assertEqual(
+            [item["id"] for item in page_after_composite_cursor(records, cursor, 1)],
+            ["evt-b"],
+        )
+
+    def test_accepts_legacy_decimal_cursor(self):
+        records = [
+            {"id": "evt-a", "occurred_at": 100},
+            {"id": "evt-b", "occurred_at": 101},
+        ]
+        self.assertEqual(
+            [item["id"] for item in page_after_composite_cursor(records, "100")],
+            ["evt-b"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Explores a versioned timestamp-and-ID cursor that can resume inside a same-timestamp group and decode existing decimal cursors.

The branch does not make older workers understand newly emitted `v2:` cursors during rollback or mixed-version execution.

Related: #398