### PR TITLE
EXP-37 Recover tied audit cursor events

### DIFF
--- a/docs/audit-export-cursors.md
+++ b/docs/audit-export-cursors.md
@@ -3,3 +3,7 @@
 Audit export cursors are opaque to API consumers, but deployed reconciliation jobs persist the returned string and may resume after a worker restart or rollback.
 
 The current production form is a decimal timestamp. Cursor changes must continue to accept that form for one release window. Ordering must remain deterministic when records are retried or inserted while an export is in progress.
+
+When more than one event has the cursor timestamp, resume delivery is at-least-once: the complete timestamp group is replayed before up to one page of newer records. Boundary replays do not count against the page limit, which lets the returned page advance to a newer timestamp when one exists. Reconciliation consumers must deduplicate replayed events by event ID.
+
+This preserves decimal cursors during mixed-version operation and prevents a page boundary from omitting tied events. Raw downloads can contain repeated boundary rows; exact-once presentation requires a separately versioned cursor contract.

--- a/src/seed_audit_cursor.py
+++ b/src/seed_audit_cursor.py
@@ -7,7 +7,18 @@ def encode_audit_cursor(record):
 
 def page_after_cursor(records, cursor=None, limit=100):
     ordered = sorted(records, key=lambda item: (item["occurred_at"], item["id"]))
-    if cursor is not None:
-        timestamp = int(cursor)
-        ordered = [item for item in ordered if item["occurred_at"] > timestamp]
-    return ordered[:limit]
+    if cursor is None:
+        return ordered[:limit]
+
+    timestamp = int(cursor)
+    boundary = [item for item in ordered if item["occurred_at"] == timestamp]
+    newer = [item for item in ordered if item["occurred_at"] > timestamp]
+
+    if len(boundary) > 1:
+        # A decimal timestamp cannot identify which tied event was emitted before
+        # the cursor was persisted. Replay the complete boundary group; callers
+        # deduplicate these records by event ID. Replays do not consume the page
+        # budget so the cursor can still advance to a newer timestamp.
+        return boundary + newer[:limit]
+
+    return newer[:limit]

--- a/tests/test_seed_audit_cursor.py
+++ b/tests/test_seed_audit_cursor.py
@@ -25,6 +25,25 @@ class AuditCursorTests(unittest.TestCase):
             ["evt-b"],
         )
 
+    def test_resume_replays_same_timestamp_boundary_without_omission(self):
+        records = [
+            {"id": "evt-106", "occurred_at": 1784217601},
+            {"id": "evt-105", "occurred_at": 1784217600},
+            {"id": "evt-104", "occurred_at": 1784217600},
+        ]
+        first_page = page_after_cursor(records, limit=1)
+        cursor = encode_audit_cursor(first_page[-1])
+
+        self.assertEqual(first_page, [records[2]])
+        self.assertEqual(cursor, "1784217600")
+        self.assertEqual(
+            [
+                item["id"]
+                for item in page_after_cursor(records, cursor=cursor, limit=1)
+            ],
+            ["evt-104", "evt-105", "evt-106"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- replay the complete cursor-timestamp group when more than one audit event shares that timestamp
- keep boundary replays outside the fresh-record page budget so a resume can advance
- preserve exclusive resume behavior for unique timestamps and the deployed decimal cursor format
- document at-least-once boundary delivery and add the RC-55 page-size-one regression

## Why

The timestamp-only cursor used an exclusive comparison. If a page ended between two events with the same `occurred_at`, the next page skipped the remaining event. During the 4.6/4.7 mixed-version window, a structured cursor is not rollback-compatible; the scheduled reconciliation importer already deduplicates by event ID, so replaying an ambiguous timestamp group is the compatibility-safe recovery.

## Impact

Scheduled reconciliation no longer omits tied boundary events. Raw consumers can receive repeated boundary rows and must deduplicate by event ID; exact-once raw presentation remains a separate product/cursor-version follow-up.

## Validation

- `python -m pytest -q tests/test_seed_audit_cursor.py`: 3 passed
- `python -m pytest -q`: 191 passed, 3 subtests passed
- `python scripts/verify_repo_baseline.py`: passed
- `git diff --check`: passed

Linear: https://linear.app/experttc3/issue/EXP-37/inc-55-audit-export-resume-omits-same-timestamp-event

Closes #398