### PR TITLE
Draft: persist replay completion before delivery

### DIFF
--- a/src/seed_replay_dispatch.py
+++ b/src/seed_replay_dispatch.py
@@ -23,8 +23,9 @@ class ReplayDispatcher:
         if not self.store.claim(stream, cursor, owner, now):
             return "skipped"
 
-        self.gateway.send(payload)
-
+        # Persisting first prevents an older owner from sending after takeover.
         if not self.store.complete(stream, cursor, owner):
             return "stale"
+
+        self.gateway.send(payload)
         return "delivered"

--- a/tests/test_seed_replay_mark_before_send.py
+++ b/tests/test_seed_replay_mark_before_send.py
@@ -1,0 +1,22 @@
+import sqlite3
+
+from src.seed_replay_claims import ReplayClaimStore
+from src.seed_replay_dispatch import ReplayDispatcher
+
+
+class Gateway:
+    def __init__(self):
+        self.calls = []
+
+    def send(self, payload):
+        self.calls.append(payload)
+
+
+def test_late_owner_is_skipped_after_completion():
+    store = ReplayClaimStore(sqlite3.connect(":memory:"))
+    gateway = Gateway()
+    dispatcher = ReplayDispatcher(store, gateway)
+
+    assert dispatcher.dispatch("billing", "evt-1", {}, "worker-a", 100) == "delivered"
+    assert dispatcher.dispatch("billing", "evt-1", {}, "worker-b", 200) == "skipped"
+    assert len(gateway.calls) == 1


### PR DESCRIPTION
Explores closing the late-callback window by making the durable completion record precede the gateway call.

Observed locally:
- repeated dispatch after a completed row is skipped
- existing replay tests remain green
- no schema migration is required

This is based on #402. The branch is intentionally narrow; failure behavior between the database write and gateway acceptance still needs review.