### PR TITLE
Draft: serialize replay lease takeover

### DIFF
--- a/src/seed_replay_claims.py
+++ b/src/seed_replay_claims.py
@@ -22,42 +22,37 @@ class ReplayClaimStore:
         )
         self.connection.commit()
 
-    def claim(
-        self,
-        stream: str,
-        cursor: str,
-        owner: str,
-        now: int,
-        lease_seconds: int = 60,
-    ) -> bool:
-        row = self.connection.execute(
-            """
-            SELECT status, lease_until
-            FROM replay_claims
-            WHERE stream = ? AND cursor = ?
-            """,
-            (stream, cursor),
-        ).fetchone()
-        if row is not None:
-            status, lease_until = row
-            if status == "delivered":
-                return False
-            if status == "claimed" and lease_until is not None and lease_until > now:
-                return False
+    def claim(self, stream: str, cursor: str, owner: str, now: int, lease_seconds: int = 60) -> bool:
+        self.connection.execute("BEGIN IMMEDIATE")
+        try:
+            row = self.connection.execute(
+                "SELECT status, lease_until FROM replay_claims WHERE stream = ? AND cursor = ?",
+                (stream, cursor),
+            ).fetchone()
+            if row is not None:
+                status, lease_until = row
+                if status == "delivered" or (
+                    status == "claimed" and lease_until is not None and lease_until > now
+                ):
+                    self.connection.rollback()
+                    return False
 
-        self.connection.execute(
-            """
-            INSERT INTO replay_claims(stream, cursor, status, owner, lease_until)
-            VALUES (?, ?, 'claimed', ?, ?)
-            ON CONFLICT(stream, cursor) DO UPDATE SET
-                status = 'claimed',
-                owner = excluded.owner,
-                lease_until = excluded.lease_until
-            """,
-            (stream, cursor, owner, now + lease_seconds),
-        )
-        self.connection.commit()
-        return True
+            self.connection.execute(
+                """
+                INSERT INTO replay_claims(stream, cursor, status, owner, lease_until)
+                VALUES (?, ?, 'claimed', ?, ?)
+                ON CONFLICT(stream, cursor) DO UPDATE SET
+                    status = 'claimed',
+                    owner = excluded.owner,
+                    lease_until = excluded.lease_until
+                """,
+                (stream, cursor, owner, now + lease_seconds),
+            )
+            self.connection.commit()
+            return True
+        except Exception:
+            self.connection.rollback()
+            raise
 
     def complete(self, stream: str, cursor: str, owner: str) -> bool:
         changed = self.connection.execute(

--- a/tests/test_seed_replay_serialized_lease.py
+++ b/tests/test_seed_replay_serialized_lease.py
@@ -1,0 +1,16 @@
+import sqlite3
+from pathlib import Path
+
+from src.seed_replay_claims import ReplayClaimStore
+
+
+def test_expired_lease_can_be_taken_after_restart(tmp_path: Path):
+    path = tmp_path / "claims.sqlite"
+    first = sqlite3.connect(path)
+    assert ReplayClaimStore(first).claim("billing", "evt-2", "worker-a", 100, 60)
+    first.close()
+
+    second = sqlite3.connect(path)
+    store = ReplayClaimStore(second)
+    assert not store.claim("billing", "evt-2", "worker-b", 159, 60)
+    assert store.claim("billing", "evt-2", "worker-b", 161, 60)


### PR DESCRIPTION
Serializes claim inspection and takeover with `BEGIN IMMEDIATE` and verifies that an expired claim is recoverable through a new SQLite connection.

This preserves the current claim schema and caller-supplied timestamp interface. It addresses the overlapping-claim race seen while reproducing #402, although the incident logs include disagreement about the exact expiry time.