### PR TITLE
Draft: fence stale replay callbacks

### DIFF
--- a/src/seed_replay_claims.py
+++ b/src/seed_replay_claims.py
@@ -1,4 +1,4 @@
-"""Durable claim records used by the replay dispatcher."""
+"""Durable replay claims with callback fencing."""
 
 from __future__ import annotations
 
@@ -16,57 +16,55 @@ class ReplayClaimStore:
                 status TEXT NOT NULL,
                 owner TEXT,
                 lease_until INTEGER,
+                fence INTEGER,
                 PRIMARY KEY (stream, cursor)
             )
             """
         )
+        columns = {
+            row[1] for row in self.connection.execute("PRAGMA table_info(replay_claims)")
+        }
+        if "fence" not in columns:
+            self.connection.execute("ALTER TABLE replay_claims ADD COLUMN fence INTEGER")
         self.connection.commit()
+        self._next_fence = 0
 
-    def claim(
-        self,
-        stream: str,
-        cursor: str,
-        owner: str,
-        now: int,
-        lease_seconds: int = 60,
-    ) -> bool:
+    def claim(self, stream: str, cursor: str, owner: str, now: int, lease_seconds: int = 60) -> int | None:
         row = self.connection.execute(
-            """
-            SELECT status, lease_until
-            FROM replay_claims
-            WHERE stream = ? AND cursor = ?
-            """,
+            "SELECT status, lease_until FROM replay_claims WHERE stream = ? AND cursor = ?",
             (stream, cursor),
         ).fetchone()
         if row is not None:
             status, lease_until = row
-            if status == "delivered":
-                return False
-            if status == "claimed" and lease_until is not None and lease_until > now:
-                return False
+            if status == "delivered" or (
+                status == "claimed" and lease_until is not None and lease_until > now
+            ):
+                return None
 
+        self._next_fence += 1
+        fence = self._next_fence
         self.connection.execute(
             """
-            INSERT INTO replay_claims(stream, cursor, status, owner, lease_until)
-            VALUES (?, ?, 'claimed', ?, ?)
+            INSERT INTO replay_claims(stream, cursor, status, owner, lease_until, fence)
+            VALUES (?, ?, 'claimed', ?, ?, ?)
             ON CONFLICT(stream, cursor) DO UPDATE SET
-                status = 'claimed',
-                owner = excluded.owner,
-                lease_until = excluded.lease_until
+                status = 'claimed', owner = excluded.owner,
+                lease_until = excluded.lease_until, fence = excluded.fence
             """,
-            (stream, cursor, owner, now + lease_seconds),
+            (stream, cursor, owner, now + lease_seconds, fence),
         )
         self.connection.commit()
-        return True
+        return fence
 
-    def complete(self, stream: str, cursor: str, owner: str) -> bool:
+    def complete(self, stream: str, cursor: str, owner: str, fence: int | None = None) -> bool:
         changed = self.connection.execute(
             """
             UPDATE replay_claims
             SET status = 'delivered', lease_until = NULL
             WHERE stream = ? AND cursor = ? AND owner = ?
+              AND (? IS NULL OR fence = ?)
             """,
-            (stream, cursor, owner),
+            (stream, cursor, owner, fence, fence),
         )
         self.connection.commit()
         return changed.rowcount == 1

--- a/src/seed_replay_dispatch.py
+++ b/src/seed_replay_dispatch.py
@@ -1,4 +1,4 @@
-"""Dispatch replayed webhook records after acquiring a durable claim."""
+"""Dispatch replayed webhook records with a callback fence."""
 
 from __future__ import annotations
 
@@ -12,19 +12,13 @@ class ReplayDispatcher:
         self.store = store
         self.gateway = gateway
 
-    def dispatch(
-        self,
-        stream: str,
-        cursor: str,
-        payload: dict[str, Any],
-        owner: str,
-        now: int,
-    ) -> str:
-        if not self.store.claim(stream, cursor, owner, now):
+    def dispatch(self, stream: str, cursor: str, payload: dict[str, Any], owner: str, now: int) -> str:
+        fence = self.store.claim(stream, cursor, owner, now)
+        if fence is None:
             return "skipped"
 
         self.gateway.send(payload)
 
-        if not self.store.complete(stream, cursor, owner):
+        if not self.store.complete(stream, cursor, owner, fence):
             return "stale"
         return "delivered"

--- a/tests/test_seed_replay_fences.py
+++ b/tests/test_seed_replay_fences.py
@@ -1,0 +1,13 @@
+import sqlite3
+
+from src.seed_replay_claims import ReplayClaimStore
+
+
+def test_old_fence_cannot_complete_after_takeover():
+    store = ReplayClaimStore(sqlite3.connect(":memory:"))
+    first = store.claim("billing", "evt-3", "shared-owner", 100, 60)
+    second = store.claim("billing", "evt-3", "shared-owner", 161, 60)
+
+    assert second > first
+    assert not store.complete("billing", "evt-3", "shared-owner", first)
+    assert store.complete("billing", "evt-3", "shared-owner", second)


### PR DESCRIPTION
Adds a fence to replay claims and carries it through completion so an older callback cannot complete a newer claim.

The focused same-process takeover test passes. The migration is additive for the rolling 4.8 window described in the repository docs. Restart behavior and how fences should interact with gateway delivery identity remain open review questions for #402.