### PR TITLE
EXP-53 make replay delivery idempotent

### DIFF
--- a/docs/replay-recovery.md
+++ b/docs/replay-recovery.md
@@ -12,5 +12,18 @@ The delivery gateway accepts an optional `idempotency_key` argument. Keys are
 opaque to the gateway. Reusing one key suppresses a repeated external delivery,
 but different keys are treated as separate attempts.
 
+`ReplayDispatcher` derives that key from the logical replay identity, not from
+worker ownership or lease state. The format is
+`replay:<stream-length>:<stream>:<cursor>`; the length prefix keeps stream and
+cursor boundaries unambiguous. A retry or replacement worker therefore reuses
+the same key even when it owns a new claim.
+
+Claim completion remains after the gateway call. If a worker stops after the
+gateway accepts a delivery but before completion is recorded, a replacement can
+retry without creating a second external delivery during the gateway's
+idempotency window. Workers from 4.8 can still read the unchanged claim schema,
+but those older dispatchers do not send the stable key. Mixed-version promotion
+must account for that limitation separately.
+
 The command-line replay tool and the background replay worker both use
 `ReplayDispatcher`.

--- a/src/seed_replay_dispatch.py
+++ b/src/seed_replay_dispatch.py
@@ -7,6 +7,12 @@ from typing import Any
 from .seed_replay_claims import ReplayClaimStore
 
 
+def replay_idempotency_key(stream: str, cursor: str) -> str:
+    """Return the stable gateway identity for one logical replay delivery."""
+
+    return f"replay:{len(stream)}:{stream}:{cursor}"
+
+
 class ReplayDispatcher:
     def __init__(self, store: ReplayClaimStore, gateway: Any) -> None:
         self.store = store
@@ -23,7 +29,10 @@ class ReplayDispatcher:
         if not self.store.claim(stream, cursor, owner, now):
             return "skipped"
 
-        self.gateway.send(payload)
+        self.gateway.send(
+            payload,
+            idempotency_key=replay_idempotency_key(stream, cursor),
+        )
 
         if not self.store.complete(stream, cursor, owner):
             return "stale"

--- a/tests/test_seed_replay_claims.py
+++ b/tests/test_seed_replay_claims.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 from src.seed_replay_claims import ReplayClaimStore
-from src.seed_replay_dispatch import ReplayDispatcher
+from src.seed_replay_dispatch import ReplayDispatcher, replay_idempotency_key
 
 
 class Gateway:
@@ -35,4 +35,80 @@ def test_dispatches_once_on_the_normal_path():
     assert dispatcher.dispatch(
         "billing", "c-19", {"event": "invoice.paid"}, "worker-a", now=100
     ) == "delivered"
-    assert len(gateway.sent) == 1
+    assert gateway.sent == [
+        (
+            {"event": "invoice.paid"},
+            {"idempotency_key": "replay:7:billing:c-19"},
+        )
+    ]
+
+
+def test_replay_identity_keeps_stream_and_cursor_boundaries():
+    assert replay_idempotency_key("billing:eu", "evt-1") != replay_idempotency_key(
+        "billing", "eu:evt-1"
+    )
+
+
+class DeduplicatingGateway:
+    def __init__(self) -> None:
+        self.attempts = []
+        self.deliveries = []
+        self.seen_keys = set()
+        self.on_first_attempt = None
+
+    def send(self, payload, **kwargs):
+        self.attempts.append((payload, kwargs))
+        key = kwargs["idempotency_key"]
+        if key not in self.seen_keys:
+            self.seen_keys.add(key)
+            self.deliveries.append(payload)
+
+        if len(self.attempts) == 1 and self.on_first_attempt is not None:
+            self.on_first_attempt()
+
+
+def test_restart_takeover_reuses_gateway_identity_and_rejects_late_completion(
+    tmp_path,
+):
+    path = tmp_path / "replay-claims.sqlite"
+    first_connection = sqlite3.connect(path)
+    first = ReplayDispatcher(ReplayClaimStore(first_connection), DeduplicatingGateway())
+    gateway = first.gateway
+    takeover = {}
+
+    def dispatch_from_replacement_worker():
+        replacement_connection = sqlite3.connect(path)
+        try:
+            replacement = ReplayDispatcher(
+                ReplayClaimStore(replacement_connection), gateway
+            )
+            takeover["result"] = replacement.dispatch(
+                "billing-eu",
+                "evt-8841",
+                {"event": "invoice.paid"},
+                "worker-b",
+                now=161,
+            )
+        finally:
+            replacement_connection.close()
+
+    gateway.on_first_attempt = dispatch_from_replacement_worker
+    try:
+        result = first.dispatch(
+            "billing-eu",
+            "evt-8841",
+            {"event": "invoice.paid"},
+            "worker-a",
+            now=100,
+        )
+    finally:
+        first_connection.close()
+
+    assert result == "stale"
+    assert takeover["result"] == "delivered"
+    assert len(gateway.attempts) == 2
+    assert gateway.attempts[0][1] == gateway.attempts[1][1]
+    assert gateway.attempts[0][1]["idempotency_key"] == (
+        "replay:10:billing-eu:evt-8841"
+    )
+    assert gateway.deliveries == [{"event": "invoice.paid"}]


### PR DESCRIPTION
## What changed

- derive one stable gateway `idempotency_key` from each replay stream/cursor pair
- reuse that identity across worker ownership changes and lease takeovers
- add a deterministic SQLite restart/takeover/late-callback regression
- document the 4.8 mixed-version limitation

## Why

A replacement worker can send the same logical replay while the original worker is still able to finish. Claim ownership alone cannot prevent both gateway calls. The gateway already suppresses repeated deliveries when callers reuse one identity, but `ReplayDispatcher` did not provide one.

This keeps claim completion after gateway acceptance, avoiding the silent-loss window in the completion-before-send prototype.

## Impact

Patched replay workers now collapse repeated gateway attempts for the same stream/cursor during the gateway idempotency window. Older 4.8 dispatchers do not send the new key, so the mixed-version promotion question remains open.

## Validation

- `python -m pytest -q tests/test_seed_replay_claims.py`: 5 passed
- `python -m pytest -q`: 196 passed, 3 subtests passed
- `python scripts/verify_repo_baseline.py`: passed
- `git diff --check`: passed
- connector-created remote tree matches the locally tested tree: `41e0f80d84d4b412324c65fc89cbcb7082d86dbf`

Linear: https://linear.app/experttc3/issue/EXP-53/confirm-replay-gateway-logical-delivery-identity
Coverage: https://linear.app/experttc3/issue/EXP-56/add-restart-takeover-and-late-callback-replay-coverage
Related: #402