### PR TITLE
Draft: restore RC-57 rollback checkpoint format

### DIFF
--- a/docs/rc57-revert-candidate.md
+++ b/docs/rc57-revert-candidate.md
@@ -2,3 +2,5 @@
 
 This branch restores the earlier rollback-readable envelope. It was prepared
 before the release-store migration was examined against an existing database.
+
+The candidate should be evaluated against the current release target.

--- a/docs/rc57-revert-candidate.md
+++ b/docs/rc57-revert-candidate.md
@@ -1,0 +1,4 @@
+# RC-57 revert candidate
+
+This branch restores the earlier rollback-readable envelope. It was prepared
+before the release-store migration was examined against an existing database.

--- a/src/rc57_checkpoint.py
+++ b/src/rc57_checkpoint.py
@@ -1,64 +1,35 @@
-"""RC-57 checkpoint codec after the generation backport."""
+"""Rollback-readable RC-57 checkpoint envelope."""
 
 from __future__ import annotations
-
-import hashlib
 
 
 class CheckpointError(ValueError):
     pass
 
 
-def _checksum(cursor: str, generation: int) -> str:
-    return hashlib.sha256(f"{cursor}:{generation}".encode()).hexdigest()[:16]
-
-
-def encode_checkpoint(
-    cursor: str,
-    generation: int,
-    rollback_tag: str | None = None,
-) -> dict[str, object]:
+def encode_checkpoint(cursor: str, rollback_tag: str | None = None) -> dict[str, object]:
     if not cursor:
         raise CheckpointError("cursor is required")
-    if generation < 1:
-        raise CheckpointError("generation must be positive")
-    raw: dict[str, object] = {
-        "schema": 2,
-        "cursor": cursor,
-        "generation": generation,
-        "checksum": _checksum(cursor, generation),
-    }
+    raw: dict[str, object] = {"schema": 1, "cursor": cursor}
     if rollback_tag is not None:
         raw["rollback_tag"] = rollback_tag
     return raw
 
 
 def decode_checkpoint(raw: dict[str, object]) -> dict[str, object]:
-    if raw.get("schema") != 2:
+    if raw.get("schema") != 1:
         raise CheckpointError("unsupported checkpoint schema")
     cursor = raw.get("cursor")
-    generation = raw.get("generation")
     if not isinstance(cursor, str) or not cursor:
         raise CheckpointError("invalid cursor")
-    if not isinstance(generation, int) or generation < 1:
-        raise CheckpointError("invalid generation")
-    if raw.get("checksum") != _checksum(cursor, generation):
-        raise CheckpointError("checkpoint checksum mismatch")
     rollback_tag = raw.get("rollback_tag")
-    if rollback_tag is not None and not isinstance(rollback_tag, str):
-        raise CheckpointError("invalid rollback tag")
     return {
         "cursor": cursor,
-        "generation": generation,
-        "rollback_tag": rollback_tag,
+        "generation": 0,
+        "rollback_tag": rollback_tag if isinstance(rollback_tag, str) else None,
     }
 
 
 def legacy_read_checkpoint(raw: dict[str, object]) -> tuple[str, str | None]:
-    if raw.get("schema") != 1:
-        raise CheckpointError("rollback reader only supports schema 1")
-    cursor = raw.get("cursor")
-    if not isinstance(cursor, str) or not cursor:
-        raise CheckpointError("invalid cursor")
-    rollback_tag = raw.get("rollback_tag")
-    return cursor, rollback_tag if isinstance(rollback_tag, str) else None
+    state = decode_checkpoint(raw)
+    return str(state["cursor"]), state["rollback_tag"]

--- a/src/rc57_promotion.py
+++ b/src/rc57_promotion.py
@@ -1,16 +1,13 @@
-"""RC-57 generation-aware promotion behavior."""
+"""RC-57 rollback-first promotion behavior."""
 
 from __future__ import annotations
 
-from .rc57_checkpoint import CheckpointError, decode_checkpoint, encode_checkpoint
+from .rc57_checkpoint import decode_checkpoint, encode_checkpoint
 
 
 def resume_checkpoint(raw: dict[str, object], generation: int) -> dict[str, object]:
     state = decode_checkpoint(raw)
-    if generation <= int(state["generation"]):
-        raise CheckpointError("generation must advance")
     return encode_checkpoint(
         str(state["cursor"]),
-        generation,
         state.get("rollback_tag") if isinstance(state.get("rollback_tag"), str) else None,
     )

--- a/tests/test_rc57_checkpoint.py
+++ b/tests/test_rc57_checkpoint.py
@@ -1,32 +1,16 @@
-import pytest
-
-from src.rc57_checkpoint import (
-    CheckpointError,
-    decode_checkpoint,
-    encode_checkpoint,
-    legacy_read_checkpoint,
-)
+from src.rc57_checkpoint import decode_checkpoint, encode_checkpoint, legacy_read_checkpoint
 from src.rc57_promotion import resume_checkpoint
 
 
-def test_current_envelope_round_trip_with_rollback_tag():
-    raw = encode_checkpoint("offset-17", 4, "blue")
-    assert decode_checkpoint(raw) == {
-        "cursor": "offset-17",
-        "generation": 4,
-        "rollback_tag": "blue",
-    }
+def test_legacy_format_keeps_release_route():
+    raw = encode_checkpoint("offset-17", "blue")
+    assert legacy_read_checkpoint(raw) == ("offset-17", "blue")
+    assert decode_checkpoint(raw)["rollback_tag"] == "blue"
 
 
-def test_legacy_reader_still_reads_a_schema_one_fixture():
-    assert legacy_read_checkpoint(
-        {"schema": 1, "cursor": "offset-18", "rollback_tag": "green"}
-    ) == ("offset-18", "green")
-
-
-def test_resume_requires_generation_advance_and_keeps_route():
-    raw = encode_checkpoint("offset-19", 4, "blue")
-    with pytest.raises(CheckpointError):
-        resume_checkpoint(raw, 4)
-    resumed = resume_checkpoint(raw, 5)
-    assert decode_checkpoint(resumed)["rollback_tag"] == "blue"
+def test_resume_keeps_cursor_and_route():
+    raw = resume_checkpoint(
+        {"schema": 1, "cursor": "offset-18", "rollback_tag": "green"},
+        5,
+    )
+    assert legacy_read_checkpoint(raw) == ("offset-18", "green")


### PR DESCRIPTION
Restores the pre-generation checkpoint writer on `release/rc-57` and keeps the release routing tag during resume.

The ordinary checkpoint tests pass on this branch. This is a revert-oriented recovery candidate for #407; the later generation-dependent call site has not been reconciled.