### PR TITLE
Draft: backport main checkpoint codec to RC-57

### DIFF
--- a/docs/rc57-main-backport-candidate.md
+++ b/docs/rc57-main-backport-candidate.md
@@ -1,0 +1,4 @@
+# RC-57 main backport candidate
+
+This branch carries the main checkpoint and persistence histories. It has not
+been reconciled with release-only routing or the current release target.

--- a/src/rc57_checkpoint.py
+++ b/src/rc57_checkpoint.py
@@ -1,29 +1,49 @@
-"""Checkpoint envelope used by the release promotion worker."""
+"""Generation-aware checkpoint codec used on main."""
 
 from __future__ import annotations
+
+import hashlib
 
 
 class CheckpointError(ValueError):
     pass
 
 
-def encode_checkpoint(cursor: str) -> dict[str, object]:
+def _checksum(cursor: str, generation: int) -> str:
+    return hashlib.sha256(f"{cursor}:{generation}".encode()).hexdigest()[:16]
+
+
+def encode_checkpoint(cursor: str, generation: int) -> dict[str, object]:
     if not cursor:
         raise CheckpointError("cursor is required")
-    return {"schema": 1, "cursor": cursor}
+    if generation < 1:
+        raise CheckpointError("generation must be positive")
+    return {
+        "schema": 2,
+        "cursor": cursor,
+        "generation": generation,
+        "checksum": _checksum(cursor, generation),
+    }
 
 
 def decode_checkpoint(raw: dict[str, object]) -> dict[str, object]:
-    if raw.get("schema") != 1:
-        raise CheckpointError("unsupported checkpoint schema")
+    schema = raw.get("schema")
     cursor = raw.get("cursor")
     if not isinstance(cursor, str) or not cursor:
         raise CheckpointError("invalid cursor")
-    return {"cursor": cursor, "generation": 0}
+    if schema == 1:
+        return {"cursor": cursor, "generation": 0}
+    if schema != 2:
+        raise CheckpointError("unsupported checkpoint schema")
+    generation = raw.get("generation")
+    if not isinstance(generation, int) or generation < 1:
+        raise CheckpointError("invalid generation")
+    if raw.get("checksum") != _checksum(cursor, generation):
+        raise CheckpointError("checkpoint checksum mismatch")
+    return {"cursor": cursor, "generation": generation}
 
 
 def legacy_read_checkpoint(raw: dict[str, object]) -> str:
-    """Reader retained by the rollback worker."""
     if raw.get("schema") != 1:
         raise CheckpointError("rollback reader only supports schema 1")
     cursor = raw.get("cursor")

--- a/src/rc57_checkpoint_store.py
+++ b/src/rc57_checkpoint_store.py
@@ -1,0 +1,52 @@
+"""Main-branch checkpoint persistence with generation migration."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+
+class CheckpointStore:
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+        self.connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS release_checkpoints (
+                name TEXT PRIMARY KEY,
+                payload TEXT NOT NULL,
+                generation INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        columns = {
+            row[1] for row in self.connection.execute("PRAGMA table_info(release_checkpoints)")
+        }
+        if "generation" not in columns:
+            self.connection.execute(
+                "ALTER TABLE release_checkpoints ADD COLUMN generation INTEGER NOT NULL DEFAULT 0"
+            )
+        self.connection.commit()
+
+    def save(self, name: str, raw: dict[str, object]) -> None:
+        self.connection.execute(
+            """
+            INSERT INTO release_checkpoints(name, payload, generation)
+            VALUES (?, ?, ?)
+            ON CONFLICT(name) DO UPDATE SET
+                payload = excluded.payload,
+                generation = excluded.generation
+            """,
+            (name, json.dumps(raw, sort_keys=True), raw.get("generation", 0)),
+        )
+        self.connection.commit()
+
+    def load(self, name: str) -> dict[str, object] | None:
+        row = self.connection.execute(
+            "SELECT payload, generation FROM release_checkpoints WHERE name = ?",
+            (name,),
+        ).fetchone()
+        if row is None:
+            return None
+        raw = json.loads(row[0])
+        raw["generation"] = row[1]
+        return raw

--- a/src/rc57_promotion.py
+++ b/src/rc57_promotion.py
@@ -1,10 +1,12 @@
-"""Promotion behavior before generation-aware resume was introduced."""
+"""Generation-aware promotion behavior on main."""
 
 from __future__ import annotations
 
-from .rc57_checkpoint import decode_checkpoint, encode_checkpoint
+from .rc57_checkpoint import CheckpointError, decode_checkpoint, encode_checkpoint
 
 
-def resume_checkpoint(raw: dict[str, object]) -> dict[str, object]:
+def resume_checkpoint(raw: dict[str, object], generation: int) -> dict[str, object]:
     state = decode_checkpoint(raw)
-    return encode_checkpoint(str(state["cursor"]))
+    if generation <= int(state["generation"]):
+        raise CheckpointError("generation must advance")
+    return encode_checkpoint(str(state["cursor"]), generation)

--- a/tests/test_rc57_checkpoint.py
+++ b/tests/test_rc57_checkpoint.py
@@ -1,27 +1,24 @@
 import pytest
 
-from src.rc57_checkpoint import (
-    CheckpointError,
-    decode_checkpoint,
-    encode_checkpoint,
-    legacy_read_checkpoint,
-)
+from src.rc57_checkpoint import CheckpointError, decode_checkpoint, encode_checkpoint
 from src.rc57_promotion import resume_checkpoint
 
 
-def test_schema_one_round_trip():
-    raw = encode_checkpoint("offset-17")
-    assert decode_checkpoint(raw)["cursor"] == "offset-17"
-    assert legacy_read_checkpoint(raw) == "offset-17"
+def test_v2_round_trip():
+    raw = encode_checkpoint("offset-17", 4)
+    assert raw["schema"] == 2
+    assert decode_checkpoint(raw) == {"cursor": "offset-17", "generation": 4}
 
 
-def test_resume_preserves_cursor():
-    assert resume_checkpoint({"schema": 1, "cursor": "offset-18"}) == {
-        "schema": 1,
+def test_reads_schema_one_rows():
+    assert decode_checkpoint({"schema": 1, "cursor": "offset-18"}) == {
         "cursor": "offset-18",
+        "generation": 0,
     }
 
 
-def test_rejects_unknown_schema():
+def test_resume_requires_generation_advance():
+    raw = encode_checkpoint("offset-19", 4)
     with pytest.raises(CheckpointError):
-        decode_checkpoint({"schema": 9, "cursor": "offset-19"})
+        resume_checkpoint(raw, 4)
+    assert decode_checkpoint(resume_checkpoint(raw, 5))["generation"] == 5

--- a/tests/test_rc57_store.py
+++ b/tests/test_rc57_store.py
@@ -1,0 +1,11 @@
+import sqlite3
+
+from src.rc57_checkpoint import encode_checkpoint
+from src.rc57_checkpoint_store import CheckpointStore
+
+
+def test_main_store_round_trip():
+    store = CheckpointStore(sqlite3.connect(":memory:"))
+    raw = encode_checkpoint("offset-501", 3)
+    store.save("promotion", raw)
+    assert store.load("promotion") == raw


### PR DESCRIPTION
Proposes using the checkpoint codec and monotonic-generation behavior currently on `main` as the release recovery.

The main-branch tests cover reading the original schema and advancing generations. This branch is intentionally based on `main`; release-only differences and the target-branch merge result still need evaluation for #407.