### PR TITLE
EXP-59 preserve RC-57 checkpoint compatibility

### DIFF
--- a/docs/rc57-checkpoints.md
+++ b/docs/rc57-checkpoints.md
@@ -7,3 +7,14 @@ release path.
 Format changes are evaluated against persisted rows, promotion behavior, and
 the rollback reader. The repository tests are the source of executable
 compatibility behavior.
+
+During the RC-57 rolling window, writers keep the schema-one envelope so the
+rollback worker can read newly persisted checkpoints. Generation and checksum
+fields are additive: a pre-generation schema-one row resumes at generation
+zero, while a newly written row binds the cursor, generation, and optional
+rollback tag in its checksum.
+
+The current worker also accepts the transitional schema-two envelope emitted
+by the earlier generation backport. Its next successful resume rewrites that
+checkpoint as schema one. Store initialization adds the missing generation
+column in place so existing release rows and routing data remain available.

--- a/src/rc57_checkpoint.py
+++ b/src/rc57_checkpoint.py
@@ -1,16 +1,26 @@
-"""RC-57 checkpoint codec after the generation backport."""
+"""Rollback-readable RC-57 checkpoint codec."""
 
 from __future__ import annotations
 
 import hashlib
+import json
 
 
 class CheckpointError(ValueError):
     pass
 
 
-def _checksum(cursor: str, generation: int) -> str:
+def _legacy_checksum(cursor: str, generation: int) -> str:
     return hashlib.sha256(f"{cursor}:{generation}".encode()).hexdigest()[:16]
+
+
+def _checksum(cursor: str, generation: int, rollback_tag: str | None) -> str:
+    payload = json.dumps(
+        [cursor, generation, rollback_tag],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
 def encode_checkpoint(
@@ -23,10 +33,10 @@ def encode_checkpoint(
     if generation < 1:
         raise CheckpointError("generation must be positive")
     raw: dict[str, object] = {
-        "schema": 2,
+        "schema": 1,
         "cursor": cursor,
         "generation": generation,
-        "checksum": _checksum(cursor, generation),
+        "checksum": _checksum(cursor, generation, rollback_tag),
     }
     if rollback_tag is not None:
         raw["rollback_tag"] = rollback_tag
@@ -34,19 +44,29 @@ def encode_checkpoint(
 
 
 def decode_checkpoint(raw: dict[str, object]) -> dict[str, object]:
-    if raw.get("schema") != 2:
+    schema = raw.get("schema")
+    if schema not in (1, 2):
         raise CheckpointError("unsupported checkpoint schema")
     cursor = raw.get("cursor")
-    generation = raw.get("generation")
+    generation = raw.get("generation", 0)
     if not isinstance(cursor, str) or not cursor:
         raise CheckpointError("invalid cursor")
-    if not isinstance(generation, int) or generation < 1:
+    if not isinstance(generation, int) or generation < 0:
         raise CheckpointError("invalid generation")
-    if raw.get("checksum") != _checksum(cursor, generation):
-        raise CheckpointError("checkpoint checksum mismatch")
     rollback_tag = raw.get("rollback_tag")
     if rollback_tag is not None and not isinstance(rollback_tag, str):
         raise CheckpointError("invalid rollback tag")
+
+    checksum = raw.get("checksum")
+    if schema == 2:
+        if generation < 1 or checksum != _legacy_checksum(cursor, generation):
+            raise CheckpointError("checkpoint checksum mismatch")
+    elif checksum is None:
+        if generation != 0:
+            raise CheckpointError("checkpoint checksum mismatch")
+    elif checksum != _checksum(cursor, generation, rollback_tag):
+        raise CheckpointError("checkpoint checksum mismatch")
+
     return {
         "cursor": cursor,
         "generation": generation,
@@ -57,8 +77,5 @@ def decode_checkpoint(raw: dict[str, object]) -> dict[str, object]:
 def legacy_read_checkpoint(raw: dict[str, object]) -> tuple[str, str | None]:
     if raw.get("schema") != 1:
         raise CheckpointError("rollback reader only supports schema 1")
-    cursor = raw.get("cursor")
-    if not isinstance(cursor, str) or not cursor:
-        raise CheckpointError("invalid cursor")
-    rollback_tag = raw.get("rollback_tag")
-    return cursor, rollback_tag if isinstance(rollback_tag, str) else None
+    state = decode_checkpoint(raw)
+    return str(state["cursor"]), state["rollback_tag"]

--- a/src/rc57_checkpoint_store.py
+++ b/src/rc57_checkpoint_store.py
@@ -19,6 +19,15 @@ class CheckpointStore:
             )
             """
         )
+        columns = {
+            row[1]
+            for row in self.connection.execute("PRAGMA table_info(release_checkpoints)")
+        }
+        if "generation" not in columns:
+            self.connection.execute(
+                "ALTER TABLE release_checkpoints "
+                "ADD COLUMN generation INTEGER NOT NULL DEFAULT 0"
+            )
         self.connection.commit()
 
     def save(self, name: str, raw: dict[str, object]) -> None:

--- a/tests/test_rc57_checkpoint.py
+++ b/tests/test_rc57_checkpoint.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 
 from src.rc57_checkpoint import (
@@ -11,6 +13,8 @@ from src.rc57_promotion import resume_checkpoint
 
 def test_current_envelope_round_trip_with_rollback_tag():
     raw = encode_checkpoint("offset-17", 4, "blue")
+    assert raw["schema"] == 1
+    assert legacy_read_checkpoint(raw) == ("offset-17", "blue")
     assert decode_checkpoint(raw) == {
         "cursor": "offset-17",
         "generation": 4,
@@ -30,3 +34,19 @@ def test_resume_requires_generation_advance_and_keeps_route():
         resume_checkpoint(raw, 4)
     resumed = resume_checkpoint(raw, 5)
     assert decode_checkpoint(resumed)["rollback_tag"] == "blue"
+
+
+def test_resume_accepts_transitional_schema_two_checkpoint():
+    persisted = {
+        "schema": 2,
+        "cursor": "offset-20",
+        "generation": 4,
+        "checksum": hashlib.sha256(b"offset-20:4").hexdigest()[:16],
+        "rollback_tag": "green",
+    }
+
+    resumed = resume_checkpoint(persisted, 5)
+
+    assert resumed["schema"] == 1
+    assert legacy_read_checkpoint(resumed) == ("offset-20", "green")
+    assert decode_checkpoint(resumed)["generation"] == 5


### PR DESCRIPTION
## What changed

- keep new RC-57 checkpoints on the rollback-readable schema-one envelope
- preserve monotonic generation ordering with additive generation and checksum fields
- bind the optional rollback route into the new checksum
- accept pre-generation schema-one rows and transitional schema-two rows already emitted by the release worker
- migrate the existing SQLite store by adding the generation column in place
- document the rolling-window compatibility contract and cover schema-two recovery

## Why

The current release worker rejected a persisted pre-generation row, while the rollback reader rejected a checkpoint newly emitted by that worker. Reproducing the release compatibility matrix on the current target produced 4 passing and 4 failing cases.

This fix-forward preserves both behaviors already required by the release: rollback-readable routing and monotonic resume generations. It does not replace the store or discard current call-site behavior.

## Impact

Existing schema-one release rows resume from generation zero. Transitional schema-two rows can be resumed and are rewritten as schema one. Newly persisted checkpoints remain readable by the rollback worker, and routing changes are detected by checksum validation.

No release artifact is promoted by this change.

## Validation

- `RC57_MATRIX=1 python -m pytest -q tests/test_rc57_checkpoint.py tests/test_rc57_store.py tests/test_rc57_release_matrix.py`: 9 passed
- `RC57_MATRIX=1 python -m pytest -q`: 205 passed, 3 subtests passed
- `python scripts/verify_repo_baseline.py`: passed
- `git diff --check`: passed
- remote tree matches the locally tested tree: `9392f8b3c0149271cf924cb4b8e21397cf44975e`

Linear: https://linear.app/experttc3/issue/EXP-59/rc-57-persisted-checkpoint-blocks-release-promotion

Related: #407