### PR TITLE
Draft: backport tenant-scoped receipts to RC-58

### DIFF
--- a/src/rc58_receipt_ledger.py
+++ b/src/rc58_receipt_ledger.py
@@ -1,4 +1,4 @@
-"""SQLite receipt ledger used by delivery reconciliation."""
+"""Tenant-scoped SQLite receipt ledger developed on main."""
 
 from __future__ import annotations
 
@@ -11,60 +11,47 @@ class ReceiptLedger:
         self.connection.execute(
             """
             CREATE TABLE IF NOT EXISTS delivery_receipts (
-                event_id TEXT PRIMARY KEY,
                 tenant_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
                 attempt INTEGER NOT NULL,
                 state TEXT NOT NULL,
-                receipt TEXT
+                receipt TEXT,
+                PRIMARY KEY (tenant_id, event_id)
             )
             """
         )
         self.connection.commit()
 
-    def record(
-        self,
-        tenant_id: str,
-        event_id: str,
-        attempt: int,
-        state: str,
-        receipt: str | None,
-    ) -> bool:
+    def record(self, tenant_id: str, event_id: str, attempt: int, state: str, receipt: str | None) -> bool:
         current = self.connection.execute(
-            "SELECT attempt FROM delivery_receipts WHERE event_id = ?",
-            (event_id,),
+            "SELECT attempt FROM delivery_receipts WHERE tenant_id = ? AND event_id = ?",
+            (tenant_id, event_id),
         ).fetchone()
         if current is not None and attempt <= current[0]:
             return False
         self.connection.execute(
             """
-            INSERT INTO delivery_receipts(event_id, tenant_id, attempt, state, receipt)
+            INSERT INTO delivery_receipts(tenant_id, event_id, attempt, state, receipt)
             VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT(event_id) DO UPDATE SET
-                tenant_id = excluded.tenant_id,
+            ON CONFLICT(tenant_id, event_id) DO UPDATE SET
                 attempt = excluded.attempt,
                 state = excluded.state,
                 receipt = excluded.receipt
             """,
-            (event_id, tenant_id, attempt, state, receipt),
+            (tenant_id, event_id, attempt, state, receipt),
         )
         self.connection.commit()
         return True
 
-    def lookup(self, event_id: str) -> dict[str, object] | None:
+    def lookup(self, tenant_id: str, event_id: str) -> dict[str, object] | None:
         row = self.connection.execute(
             """
             SELECT tenant_id, event_id, attempt, state, receipt
             FROM delivery_receipts
-            WHERE event_id = ?
+            WHERE tenant_id = ? AND event_id = ?
             """,
-            (event_id,),
+            (tenant_id, event_id),
         ).fetchone()
         if row is None:
             return None
-        return {
-            "tenant_id": row[0],
-            "event_id": row[1],
-            "attempt": row[2],
-            "state": row[3],
-            "receipt": row[4],
-        }
+        return dict(zip(("tenant_id", "event_id", "attempt", "state", "receipt"), row))

--- a/tests/test_rc58_receipt_ledger.py
+++ b/tests/test_rc58_receipt_ledger.py
@@ -3,17 +3,17 @@ import sqlite3
 from src.rc58_receipt_ledger import ReceiptLedger
 
 
-def test_newer_attempt_replaces_older_attempt():
+def test_same_event_is_independent_across_tenants():
     ledger = ReceiptLedger(sqlite3.connect(":memory:"))
 
-    assert ledger.record("tenant-a", "evt-17", 1, "pending", None)
-    assert ledger.record("tenant-a", "evt-17", 2, "delivered", "receipt-2")
-    assert ledger.lookup("evt-17")["receipt"] == "receipt-2"
+    assert ledger.record("tenant-a", "evt-17", 1, "delivered", "receipt-a")
+    assert ledger.record("tenant-b", "evt-17", 1, "delivered", "receipt-b")
+
+    assert ledger.lookup("tenant-a", "evt-17")["receipt"] == "receipt-a"
+    assert ledger.lookup("tenant-b", "evt-17")["receipt"] == "receipt-b"
 
 
-def test_stale_attempt_is_ignored():
+def test_stale_attempt_is_ignored_per_tenant():
     ledger = ReceiptLedger(sqlite3.connect(":memory:"))
-
     assert ledger.record("tenant-a", "evt-18", 4, "retracted", None)
     assert not ledger.record("tenant-a", "evt-18", 3, "delivered", "late")
-    assert ledger.lookup("evt-18")["state"] == "retracted"


### PR DESCRIPTION
Carries the tenant-scoped receipt identity currently on main into the RC-58 release line.

The main tests cover repeated upstream event IDs across tenants and stale attempts. The branch predates release-only destination routing and has not been reconciled with the existing release database.

Superseded by #416, which was validated and merged into `release/rc-58` with full-route identity and existing-store migration.