### PR TITLE
Draft: key RC-58 receipts by full route

### DIFF
--- a/src/rc58_receipt_ledger.py
+++ b/src/rc58_receipt_ledger.py
@@ -1,4 +1,4 @@
-"""RC-58 route-aware receipt ledger."""
+"""Fresh-database route-scoped receipt ledger."""
 
 from __future__ import annotations
 
@@ -11,69 +11,53 @@ class ReceiptLedger:
         self.connection.execute(
             """
             CREATE TABLE IF NOT EXISTS delivery_receipts (
-                event_id TEXT PRIMARY KEY,
                 tenant_id TEXT NOT NULL,
                 destination_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
                 attempt INTEGER NOT NULL,
                 state TEXT NOT NULL,
-                receipt TEXT
+                receipt TEXT,
+                PRIMARY KEY (tenant_id, destination_id, event_id)
             )
             """
         )
         self.connection.commit()
 
-    def record(
-        self,
-        tenant_id: str,
-        destination_id: str,
-        event_id: str,
-        attempt: int,
-        state: str,
-        receipt: str | None,
-    ) -> bool:
+    def record(self, tenant_id: str, destination_id: str, event_id: str, attempt: int, state: str, receipt: str | None) -> bool:
+        key = (tenant_id, destination_id, event_id)
         current = self.connection.execute(
-            "SELECT attempt FROM delivery_receipts WHERE event_id = ?",
-            (event_id,),
+            """
+            SELECT attempt FROM delivery_receipts
+            WHERE tenant_id = ? AND destination_id = ? AND event_id = ?
+            """,
+            key,
         ).fetchone()
         if current is not None and attempt <= current[0]:
             return False
         self.connection.execute(
             """
             INSERT INTO delivery_receipts(
-                event_id, tenant_id, destination_id, attempt, state, receipt
-            )
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(event_id) DO UPDATE SET
-                tenant_id = excluded.tenant_id,
-                destination_id = excluded.destination_id,
+                tenant_id, destination_id, event_id, attempt, state, receipt
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id, destination_id, event_id) DO UPDATE SET
                 attempt = excluded.attempt,
                 state = excluded.state,
                 receipt = excluded.receipt
             """,
-            (event_id, tenant_id, destination_id, attempt, state, receipt),
+            (*key, attempt, state, receipt),
         )
         self.connection.commit()
         return True
 
-    def lookup(
-        self,
-        tenant_id: str,
-        destination_id: str,
-        event_id: str,
-    ) -> dict[str, object] | None:
+    def lookup(self, tenant_id: str, destination_id: str, event_id: str) -> dict[str, object] | None:
         row = self.connection.execute(
             """
             SELECT tenant_id, destination_id, event_id, attempt, state, receipt
             FROM delivery_receipts
-            WHERE event_id = ?
+            WHERE tenant_id = ? AND destination_id = ? AND event_id = ?
             """,
-            (event_id,),
+            (tenant_id, destination_id, event_id),
         ).fetchone()
-        if row is None or row[0] != tenant_id or row[1] != destination_id:
+        if row is None:
             return None
-        return dict(
-            zip(
-                ("tenant_id", "destination_id", "event_id", "attempt", "state", "receipt"),
-                row,
-            )
-        )
+        return dict(zip(("tenant_id", "destination_id", "event_id", "attempt", "state", "receipt"), row))


### PR DESCRIPTION
Uses tenant, destination, and upstream event ID as the primary key for fresh receipt databases.

Fresh-store route and retry tests pass. Existing RC-58 databases use an earlier table shape, so this branch does not yet establish an upgrade path.

Superseded by #416, which retained the full-route key and added the validated existing-store migration.