### PR TITLE
EXP-63 scope RC-58 receipts by delivery route

### DIFF
--- a/docs/rc58-receipts.md
+++ b/docs/rc58-receipts.md
@@ -1,9 +1,13 @@
 # RC-58 receipt reconciliation
 
 The delivery receipt ledger is consulted after retry and coordinator failover.
-Receipt identity is scoped by the delivery route, while attempt ordering prevents
-an older callback from replacing newer state.
+Receipt identity is the `(tenant_id, destination_id, event_id)` delivery route,
+while attempt ordering within that route prevents an older callback from
+replacing newer state.
 
 The supported release window includes databases created before route-aware
-receipt tracking. Repository validation must cover both fresh and existing
-SQLite stores.
+receipt tracking. Opening one of those stores migrates its existing rows in a
+single transaction and assigns `webhook-primary` as their historical
+destination. Stores that already contain destination values retain them while
+their primary key is upgraded to the full route. Repository validation must
+cover fresh, pre-route, and route-aware SQLite stores.

--- a/src/rc58_receipt_ledger.py
+++ b/src/rc58_receipt_ledger.py
@@ -1,26 +1,83 @@
-"""RC-58 route-aware receipt ledger."""
+"""RC-58 route-aware receipt ledger with legacy-store migration."""
 
 from __future__ import annotations
 
 import sqlite3
 
 
+_COLUMNS = (
+    "tenant_id",
+    "destination_id",
+    "event_id",
+    "attempt",
+    "state",
+    "receipt",
+)
+_PRIMARY_KEY = ("tenant_id", "destination_id", "event_id")
+_LEGACY_DESTINATION = "webhook-primary"
+
+
 class ReceiptLedger:
     def __init__(self, connection: sqlite3.Connection) -> None:
         self.connection = connection
+        columns = list(self.connection.execute("PRAGMA table_info(delivery_receipts)"))
+        if columns:
+            names = {row[1] for row in columns}
+            primary_key = tuple(
+                row[1]
+                for row in sorted(columns, key=lambda row: row[5])
+                if row[5] > 0
+            )
+            if "destination_id" not in names or primary_key != _PRIMARY_KEY:
+                self._migrate(names)
+            return
+
+        self._create_table("delivery_receipts")
+        self.connection.commit()
+
+    def _create_table(self, table: str) -> None:
         self.connection.execute(
-            """
-            CREATE TABLE IF NOT EXISTS delivery_receipts (
-                event_id TEXT PRIMARY KEY,
+            f"""
+            CREATE TABLE {table} (
                 tenant_id TEXT NOT NULL,
                 destination_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
                 attempt INTEGER NOT NULL,
                 state TEXT NOT NULL,
-                receipt TEXT
+                receipt TEXT,
+                PRIMARY KEY (tenant_id, destination_id, event_id)
             )
             """
         )
-        self.connection.commit()
+
+    def _migrate(self, columns: set[str]) -> None:
+        destination = (
+            "destination_id"
+            if "destination_id" in columns
+            else f"'{_LEGACY_DESTINATION}'"
+        )
+
+        self.connection.execute("BEGIN IMMEDIATE")
+        try:
+            self.connection.execute("DROP TABLE IF EXISTS delivery_receipts_v2")
+            self._create_table("delivery_receipts_v2")
+            self.connection.execute(
+                f"""
+                INSERT INTO delivery_receipts_v2(
+                    tenant_id, destination_id, event_id, attempt, state, receipt
+                )
+                SELECT tenant_id, {destination}, event_id, attempt, state, receipt
+                FROM delivery_receipts
+                """
+            )
+            self.connection.execute("DROP TABLE delivery_receipts")
+            self.connection.execute(
+                "ALTER TABLE delivery_receipts_v2 RENAME TO delivery_receipts"
+            )
+            self.connection.commit()
+        except Exception:
+            self.connection.rollback()
+            raise
 
     def record(
         self,
@@ -31,26 +88,27 @@ class ReceiptLedger:
         state: str,
         receipt: str | None,
     ) -> bool:
+        key = (tenant_id, destination_id, event_id)
         current = self.connection.execute(
-            "SELECT attempt FROM delivery_receipts WHERE event_id = ?",
-            (event_id,),
+            """
+            SELECT attempt FROM delivery_receipts
+            WHERE tenant_id = ? AND destination_id = ? AND event_id = ?
+            """,
+            key,
         ).fetchone()
         if current is not None and attempt <= current[0]:
             return False
         self.connection.execute(
             """
             INSERT INTO delivery_receipts(
-                event_id, tenant_id, destination_id, attempt, state, receipt
-            )
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(event_id) DO UPDATE SET
-                tenant_id = excluded.tenant_id,
-                destination_id = excluded.destination_id,
+                tenant_id, destination_id, event_id, attempt, state, receipt
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id, destination_id, event_id) DO UPDATE SET
                 attempt = excluded.attempt,
                 state = excluded.state,
                 receipt = excluded.receipt
             """,
-            (event_id, tenant_id, destination_id, attempt, state, receipt),
+            (*key, attempt, state, receipt),
         )
         self.connection.commit()
         return True
@@ -65,15 +123,10 @@ class ReceiptLedger:
             """
             SELECT tenant_id, destination_id, event_id, attempt, state, receipt
             FROM delivery_receipts
-            WHERE event_id = ?
+            WHERE tenant_id = ? AND destination_id = ? AND event_id = ?
             """,
-            (event_id,),
+            (tenant_id, destination_id, event_id),
         ).fetchone()
-        if row is None or row[0] != tenant_id or row[1] != destination_id:
+        if row is None:
             return None
-        return dict(
-            zip(
-                ("tenant_id", "destination_id", "event_id", "attempt", "state", "receipt"),
-                row,
-            )
-        )
+        return dict(zip(_COLUMNS, row))

--- a/tests/test_rc58_release_matrix.py
+++ b/tests/test_rc58_release_matrix.py
@@ -32,6 +32,26 @@ def test_same_event_id_does_not_cross_tenant_boundary():
     )
 
 
+def test_same_event_id_does_not_cross_destination_boundary():
+    ledger = ReceiptLedger(sqlite3.connect(":memory:"))
+
+    assert ledger.record(
+        "tenant-a", "webhook-primary", "evt-shared", 4, "retracted", None
+    )
+    assert ledger.record(
+        "tenant-a", "audit-archive", "evt-shared", 1, "delivered", "receipt-b"
+    )
+
+    assert (
+        ledger.lookup("tenant-a", "webhook-primary", "evt-shared")["state"]
+        == "retracted"
+    )
+    assert (
+        ledger.lookup("tenant-a", "audit-archive", "evt-shared")["receipt"]
+        == "receipt-b"
+    )
+
+
 def test_existing_receipt_table_accepts_route_aware_recording():
     connection = sqlite3.connect(":memory:")
     connection.execute(
@@ -55,10 +75,93 @@ def test_existing_receipt_table_accepts_route_aware_recording():
 
     ledger = ReceiptLedger(connection)
 
-    assert ledger.lookup("tenant-a", "webhook-primary", "evt-old")["receipt"] == "legacy-receipt"
+    assert (
+        ledger.lookup("tenant-a", "webhook-primary", "evt-old")["receipt"]
+        == "legacy-receipt"
+    )
     assert ledger.record(
         "tenant-a", "webhook-primary", "evt-new", 1, "pending", None
     )
+    assert connection.execute("SELECT COUNT(*) FROM delivery_receipts").fetchone() == (
+        2,
+    )
+
+
+def test_existing_route_aware_table_gains_full_route_identity():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        """
+        CREATE TABLE delivery_receipts (
+            event_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            destination_id TEXT NOT NULL,
+            attempt INTEGER NOT NULL,
+            state TEXT NOT NULL,
+            receipt TEXT
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO delivery_receipts(
+            event_id, tenant_id, destination_id, attempt, state, receipt
+        ) VALUES ('evt-old', 'tenant-a', 'audit-archive', 4, 'retracted', NULL)
+        """
+    )
+    connection.commit()
+
+    ledger = ReceiptLedger(connection)
+
+    primary_key = tuple(
+        row[1]
+        for row in sorted(
+            connection.execute("PRAGMA table_info(delivery_receipts)"),
+            key=lambda row: row[5],
+        )
+        if row[5] > 0
+    )
+    assert primary_key == ("tenant_id", "destination_id", "event_id")
+    assert (
+        ledger.lookup("tenant-a", "audit-archive", "evt-old")["state"]
+        == "retracted"
+    )
+    assert ledger.record(
+        "tenant-a", "webhook-primary", "evt-old", 1, "delivered", "receipt-new"
+    )
+    assert ReceiptLedger(connection).lookup(
+        "tenant-a", "audit-archive", "evt-old"
+    )["state"] == "retracted"
+
+
+def test_failed_migration_leaves_the_original_receipt_table_intact():
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        """
+        CREATE TABLE delivery_receipts (
+            event_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            attempt INTEGER NOT NULL,
+            state TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO delivery_receipts(event_id, tenant_id, attempt, state)
+        VALUES ('evt-old', 'tenant-a', 2, 'delivered')
+        """
+    )
+    connection.commit()
+
+    with pytest.raises(sqlite3.OperationalError):
+        ReceiptLedger(connection)
+
+    assert connection.execute(
+        "SELECT event_id, tenant_id, attempt, state FROM delivery_receipts"
+    ).fetchall() == [("evt-old", "tenant-a", 2, "delivered")]
+    assert connection.execute(
+        "SELECT name FROM sqlite_master WHERE name = 'delivery_receipts_v2'"
+    ).fetchone() is None
 
 
 def test_retracted_receipt_remains_route_local():


### PR DESCRIPTION
## Summary

- key RC-58 receipt identity by the full `(tenant_id, destination_id, event_id)` delivery route
- scope attempt ordering and retraction protection to that route
- transactionally migrate both pre-route and route-aware SQLite stores without dropping existing receipts
- document the compatibility behavior and assign `webhook-primary` only to rows that predate destination tracking

## Root cause and impact

The release ledger keyed every receipt by upstream event ID alone. Reused event IDs therefore collided across tenants and destinations, allowing one route's attempt ordering or retraction state to hide another route's receipt during failover reconciliation.

The new composite key keeps routes independent while preserving retry ordering within each route. Migration failures roll back to the original table.

## Validation

- `RC58_MATRIX=1 python -m pytest tests/test_rc58_receipt_ledger.py tests/test_rc58_release_matrix.py` — 8 passed
- `python -m pytest` on Python 3.12.13 — 202 passed, 6 intentionally gated RC-58 tests skipped
- `python scripts/verify_repo_baseline.py` — passed
- `git diff --check` — passed
- connector-created tree `14600439cb2a0d079e69bd870b544162fc9f7731` matches the locally tested Git tree

## Scope

This is a repository-level fix only. It does not promote RC-58, run a production reconciliation, or establish customer impact.

Linear: https://linear.app/experttc3/issue/EXP-63/rc-58-receipt-reconciliation-crosses-release-routes

Closes #412