### PR TITLE
Include timezone in export preview names

### DIFF
--- a/src/rc59_preview.py
+++ b/src/rc59_preview.py
@@ -16,8 +16,9 @@ class PlanCache:
 
 def format_preview(records: Iterable[str], timezone: str = "UTC") -> dict[str, object]:
     values = list(records)
+    timezone_slug = timezone.lower().replace("/", "-")
     return {
-        "name": f"export-preview-{len(values)}",
+        "name": f"export-preview-{timezone_slug}-{len(values)}",
         "timezone": timezone,
         "record_count": len(values),
         "records": values,

--- a/tests/test_rc59_preview.py
+++ b/tests/test_rc59_preview.py
@@ -8,6 +8,7 @@ def test_preview_contains_records_and_timezone():
 
     assert plan["record_count"] == 2
     assert plan["timezone"] == "America/Sao_Paulo"
+    assert plan["name"] == "export-preview-america-sao_paulo-2"
 
 
 def test_preview_can_be_saved_for_later_use():


### PR DESCRIPTION
Fixes #417.

Preview names now include a normalized timezone slug, while the existing plan payload keeps the original timezone value.

Validation: focused preview tests and repository CI.