### PR TITLE
Draft: make export preview payloads explicit

### DIFF
--- a/src/rc59_preview.py
+++ b/src/rc59_preview.py
@@ -18,6 +18,7 @@ def format_preview(records: Iterable[str], timezone: str = "UTC") -> dict[str, o
     values = list(records)
     timezone_slug = timezone.lower().replace("/", "-")
     return {
+        "mode": "preview",
         "name": f"export-preview-{timezone_slug}-{len(values)}",
         "timezone": timezone,
         "record_count": len(values),

--- a/tests/test_rc59_preview.py
+++ b/tests/test_rc59_preview.py
@@ -1,11 +1,12 @@
 from src.rc59_preview import PlanCache, preview_export
 
 
-def test_preview_contains_records_and_timezone():
+def test_preview_contains_records_timezone_and_mode():
     cache = PlanCache()
 
     plan = preview_export(["evt-1", "evt-2"], cache, timezone="America/Sao_Paulo")
 
+    assert plan["mode"] == "preview"
     assert plan["record_count"] == 2
     assert plan["timezone"] == "America/Sao_Paulo"
     assert plan["name"] == "export-preview-america-sao_paulo-2"


### PR DESCRIPTION
Adds an explicit preview mode to the formatted export plan and updates the rendering-focused tests.

This was started from the preview inspection discussion. Persistence behavior is not covered by the current branch tests.