### PR TITLE
Prevent previews from overwriting saved export plans

### DIFF
--- a/docs/rc59-preview.md
+++ b/docs/rc59-preview.md
@@ -1,7 +1,8 @@
 # Export preview behavior
 
 Export preview and inspection commands show the plan that a later export would
-use. The optional save-plan action retains a plan for later reuse.
+use without changing reusable plan state. The optional save-plan action retains
+a plan for later reuse.
 
 Preview naming, rendering, and persistence are separate concerns. Repository
 tests define the command behavior used by TC1.

--- a/src/rc59_preview.py
+++ b/src/rc59_preview.py
@@ -33,5 +33,6 @@ def preview_export(
     save_plan: bool = False,
 ) -> dict[str, object]:
     plan = format_preview(records, timezone)
-    cache.save(plan)
+    if save_plan:
+        cache.save(plan)
     return plan

--- a/tests/test_rc59_preview.py
+++ b/tests/test_rc59_preview.py
@@ -11,6 +11,16 @@ def test_preview_contains_records_and_timezone():
     assert plan["name"] == "export-preview-america-sao_paulo-2"
 
 
+def test_preview_is_read_only_by_default():
+    cache = PlanCache()
+    saved_plan = preview_export(["scheduled-event"], cache, save_plan=True)
+
+    preview = preview_export(["inspection-event"], cache)
+
+    assert preview["records"] == ["inspection-event"]
+    assert cache.saved == [saved_plan]
+
+
 def test_preview_can_be_saved_for_later_use():
     cache = PlanCache()
 


### PR DESCRIPTION
## What changed

- Persist export plans only when the caller explicitly passes `save_plan=True`.
- Add regression coverage that starts with a saved scheduled plan and proves a different ordinary preview leaves reusable state unchanged.
- Clarify the read-only preview contract in the RC-59 behavior note.

## Why

Ordinary preview currently accepts `save_plan=False` but ignores it and always writes to `PlanCache`. A later scheduled run can therefore consume the inspected records instead of the plan the operator deliberately saved.

## Impact

Preview and inspection remain read-only by default. The explicit save-plan behavior and returned preview payload are unchanged.

## Validation

- `python -m pytest tests/test_rc59_preview.py -q`: 3 passed
- `python -m pytest -q`: 205 passed, 3 subtests passed
- `python scripts/verify_repo_baseline.py`: passed
- `git diff --check`: passed
- Published GitHub tree `6cb0edac87021abadc8448b2c02b59dbdc216e53` matches the locally tested tree exactly

Linear: [EXP-67](https://linear.app/experttc3/issue/EXP-67/keep-inspection-commands-side-effect-free)

Closes #419