### PR TITLE
Normalize copied owner labels before grouping

### DIFF
--- a/src/seed_coverage_owner_unicode.py
+++ b/src/seed_coverage_owner_unicode.py
@@ -1,0 +1,6 @@
+"""Owner identity normalization used by delivery grouping."""
+
+
+def canonical_owner(value: str) -> str:
+    """Normalize common copied-label differences without changing display data."""
+    return " ".join(value.strip().split()).casefold()


### PR DESCRIPTION
Normalizes case and ordinary surrounding/internal whitespace before owner identities are grouped while leaving configured display labels unchanged.

Current regression coverage exercises ASCII case differences and normal spaces. Copied non-breaking-space and Unicode-equivalence examples were discussed but are not included in this branch.

The behavior is used by CSV and replay grouping paths.