### PR TITLE
Reject invalid batch sizes before enqueue

### DIFF
--- a/src/seed_batch_size_validation.py
+++ b/src/seed_batch_size_validation.py
@@ -1,0 +1,9 @@
+"""Batch-size validation for delivery enqueue operations."""
+
+
+def validate_batch_size(value: int, maximum: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError("batch size must be an integer")
+    if value < 1 or value > maximum:
+        raise ValueError(f"batch size must be between 1 and {maximum}")
+    return value

--- a/tests/test_seed_batch_size_validation.py
+++ b/tests/test_seed_batch_size_validation.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.seed_batch_size_validation import validate_batch_size
+
+
+@pytest.mark.parametrize("value", [0, -1, 101])
+def test_rejects_values_outside_allowed_range(value):
+    with pytest.raises(ValueError):
+        validate_batch_size(value, 100)
+
+
+def test_accepts_minimum_and_maximum():
+    assert validate_batch_size(1, 100) == 1
+    assert validate_batch_size(100, 100) == 100
+
+
+def test_rejects_boolean_and_non_integer_values():
+    with pytest.raises(TypeError):
+        validate_batch_size(True, 100)
+    with pytest.raises(TypeError):
+        validate_batch_size("10", 100)


### PR DESCRIPTION
Validates type, minimum, and configured maximum before a delivery batch is enqueued.

Focused tests cover zero, negative values, maximum-plus-one, both valid boundaries, booleans, and non-integer input. Review discussion still questions the chosen exception wording, but no uncovered behavior has been identified.