### PR TITLE
Document preview payload metadata

### DIFF
--- a/docs/seed_preview_payload_metadata.md
+++ b/docs/seed_preview_payload_metadata.md
@@ -1,0 +1,6 @@
+# Preview payload metadata
+
+Preview responses expose a `mode`, selected timezone, record count, and display name.
+This note documents the existing response shape for support and release runbooks.
+
+No runtime code, schema, or generated artifact changes in this branch.


### PR DESCRIPTION
Documents the existing preview response fields used by support and the release runbook.

This branch changes documentation only. It does not alter runtime code, schemas, generated examples, or executable configuration.