### PR TITLE
Add optional owner filter to delivery summaries

### DIFF
--- a/src/seed_owner_filter.py
+++ b/src/seed_owner_filter.py
@@ -1,0 +1,14 @@
+"""Owner filtering used by delivery-summary previews."""
+
+
+def filter_delivery_records(records, owners=None):
+    """Return records for selected owners while preserving input order."""
+    if owners is None:
+        return list(records)
+
+    selected = {str(owner).casefold() for owner in owners}
+    return [
+        record
+        for record in records
+        if str(record["owner"]).casefold() in selected
+    ]

--- a/tests/test_seed_owner_filter.py
+++ b/tests/test_seed_owner_filter.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.seed_owner_filter import filter_delivery_records
+
+
+def test_none_owner_filter_preserves_all_records_in_order():
+    records = [
+        {"owner": "payments", "id": "a"},
+        {"owner": "risk", "id": "b"},
+    ]
+
+    assert filter_delivery_records(records) == records
+
+
+def test_populated_owner_filter_is_case_insensitive_and_preserves_order():
+    records = [
+        {"owner": "Payments", "id": "a"},
+        {"owner": "risk", "id": "b"},
+        {"owner": "PAYMENTS", "id": "c"},
+    ]
+
+    assert filter_delivery_records(records, owners=["payments"]) == [
+        records[0],
+        records[2],
+    ]
+
+
+@pytest.mark.skip(reason="empty-list semantics awaiting product decision")
+def test_empty_owner_filter_contract():
+    assert filter_delivery_records(
+        [{"owner": "payments", "id": "a"}],
+        owners=[],
+    ) == []


### PR DESCRIPTION
Adds an optional owner filter to delivery summaries.

Coverage status:
- no filter (None) is covered;
- populated filters, case folding, and ordering are covered;
- the empty-list contract is explicitly deferred and its regression test remains skipped pending a product decision on whether [] means “no owners” or “no restriction”.

That deferred case should remain tracked until the behavior is decided and the test can be enabled.