### PR TITLE
Carry owner context into resumed delivery

### DIFF
--- a/src/retry_owner_context.py
+++ b/src/retry_owner_context.py
@@ -1,0 +1,6 @@
+"""Owner selection for delayed delivery attempts."""
+
+
+def owner_for_attempt(original_owner, owner_override=None):
+    """Return the owner recorded for a resumed attempt."""
+    return owner_override or original_owner

--- a/tests/test_retry_owner_context.py
+++ b/tests/test_retry_owner_context.py
@@ -1,0 +1,9 @@
+from src.retry_owner_context import owner_for_attempt
+
+
+def test_retry_uses_operator_override():
+    assert owner_for_attempt("routing-default", "ops-east") == "ops-east"
+
+
+def test_retry_without_override_uses_original_owner():
+    assert owner_for_attempt("routing-default") == "routing-default"


### PR DESCRIPTION
Carries the operator-selected owner value from a queued delivery into a resumed attempt.

This path is used after timeout recovery and manual replay. The queue representation uses `None` when no override was supplied; values may originate in CSV imports or operator edits.