### PR TITLE
Accept cursor aliases during client rollout

### DIFF
--- a/src/cursor_alias.py
+++ b/src/cursor_alias.py
@@ -3,4 +3,6 @@
 
 def select_cursor(parameters):
     """Read a cursor while old and new clients overlap."""
-    return parameters.get("after") or parameters.get("cursor")
+    if "cursor" in parameters:
+        return parameters["cursor"]
+    return parameters.get("after")

--- a/src/cursor_alias.py
+++ b/src/cursor_alias.py
@@ -1,0 +1,6 @@
+"""Compatibility handling for paginated delivery cursors."""
+
+
+def select_cursor(parameters):
+    """Read a cursor while old and new clients overlap."""
+    return parameters.get("after") or parameters.get("cursor")

--- a/tests/test_cursor_alias.py
+++ b/tests/test_cursor_alias.py
@@ -7,3 +7,10 @@ def test_reads_legacy_alias():
 
 def test_reads_canonical_cursor():
     assert select_cursor({"cursor": "page-18"}) == "page-18"
+
+
+def test_canonical_cursor_wins_during_client_overlap():
+    assert select_cursor({
+        "after": "page-17",
+        "cursor": "page-18",
+    }) == "page-18"

--- a/tests/test_cursor_alias.py
+++ b/tests/test_cursor_alias.py
@@ -1,0 +1,9 @@
+from src.cursor_alias import select_cursor
+
+
+def test_reads_legacy_alias():
+    assert select_cursor({"after": "page-17"}) == "page-17"
+
+
+def test_reads_canonical_cursor():
+    assert select_cursor({"cursor": "page-18"}) == "page-18"


### PR DESCRIPTION
Accepts both pagination field names while dashboard and worker clients roll independently.

The canonical request field is `cursor`; `after` remains accepted for clients that have not yet been upgraded.