### PR TITLE
Show trace source beside delivery previews

### DIFF
--- a/src/preview_trace.py
+++ b/src/preview_trace.py
@@ -1,0 +1,7 @@
+"""Formatting helpers for delivery preview metadata."""
+
+
+def preview_trace_label(trace_id, source):
+    """Return a compact operator-facing trace label."""
+    normalized_source = (source or "unknown").strip() or "unknown"
+    return f"{normalized_source}:{trace_id}"

--- a/tests/test_preview_trace.py
+++ b/tests/test_preview_trace.py
@@ -1,0 +1,9 @@
+from src.preview_trace import preview_trace_label
+
+
+def test_preview_trace_label_includes_source_and_id():
+    assert preview_trace_label("tr-18", "csv") == "csv:tr-18"
+
+
+def test_preview_trace_label_normalizes_missing_source():
+    assert preview_trace_label("tr-19", "  ") == "unknown:tr-19"


### PR DESCRIPTION
Adds the compact trace label shown beside delivery preview rows.

The value is presentation-only and is derived from the existing source and trace identifier fields; no persisted payload shape changes.