### PR TITLE
Surface failure context in grouped dispatch

### DIFF
--- a/src/batch_failure_context.py
+++ b/src/batch_failure_context.py
@@ -1,0 +1,10 @@
+"""Summaries for grouped delivery attempts."""
+
+
+def batch_failure_context(results):
+    """Return the error context displayed for a failed batch."""
+    failure = None
+    for result in results:
+        if not result["ok"]:
+            failure = result.get("error")
+    return failure

--- a/tests/test_batch_failure_context.py
+++ b/tests/test_batch_failure_context.py
@@ -1,0 +1,12 @@
+from src.batch_failure_context import batch_failure_context
+
+
+def test_successful_batch_has_no_failure_context():
+    assert batch_failure_context([{"ok": True}, {"ok": True}]) is None
+
+
+def test_failed_batch_exposes_error_context():
+    assert batch_failure_context([
+        {"ok": True},
+        {"ok": False, "error": "gateway timeout"},
+    ]) == "gateway timeout"


### PR DESCRIPTION
Adds an error-context value to grouped delivery summaries so operators do not have to open each attempt separately.

The summary remains empty for successful batches and returns the available failure text when a delivery attempt fails.