### PR TITLE
Apply release target to queued promotions

### DIFF
--- a/src/promotion_target.py
+++ b/src/promotion_target.py
@@ -1,0 +1,6 @@
+"""Target selection for queued promotion actions."""
+
+
+def target_for_promotion(action, current_target):
+    """Choose the deployment target when a queued action is applied."""
+    return action.get("target") or current_target

--- a/tests/test_promotion_target.py
+++ b/tests/test_promotion_target.py
@@ -1,0 +1,9 @@
+from src.promotion_target import target_for_promotion
+
+
+def test_action_without_target_uses_current_release_target():
+    assert target_for_promotion({}, "green") == "green"
+
+
+def test_action_target_is_retained():
+    assert target_for_promotion({"target": "blue"}, "blue") == "blue"


### PR DESCRIPTION
Uses release target information when applying promotion actions that may have waited in the control-plane queue.

Actions produced by older clients can omit the target. Newer actions include the target that was visible when the request was prepared.