### PR TITLE
Normalize preview timezone aliases for RC-60

### DIFF
--- a/src/rc59_preview.py
+++ b/src/rc59_preview.py
@@ -14,9 +14,14 @@ class PlanCache:
         self.saved.append(dict(plan))
 
 
+def _timezone_slug(timezone: str) -> str:
+    compacted = " ".join(timezone.strip().split())
+    return compacted.lower().replace("/", "-").replace(" ", "-")
+
+
 def format_preview(records: Iterable[str], timezone: str = "UTC") -> dict[str, object]:
     values = list(records)
-    timezone_slug = timezone.lower().replace("/", "-")
+    timezone_slug = _timezone_slug(timezone)
     return {
         "name": f"export-preview-{timezone_slug}-{len(values)}",
         "timezone": timezone,

--- a/src/rc59_preview.py
+++ b/src/rc59_preview.py
@@ -15,7 +15,7 @@ class PlanCache:
 
 
 def _timezone_slug(timezone: str) -> str:
-    compacted = " ".join(timezone.strip().split())
+    compacted = " ".join(timezone.strip().replace("_", " ").split())
     return compacted.lower().replace("/", "-").replace(" ", "-")
 
 

--- a/tests/test_rc59_preview.py
+++ b/tests/test_rc59_preview.py
@@ -11,6 +11,15 @@ def test_preview_contains_records_and_timezone():
     assert plan["name"] == "export-preview-america-sao_paulo-2"
 
 
+def test_preview_name_normalizes_spaced_timezone_label():
+    cache = PlanCache()
+
+    plan = preview_export(["evt-1"], cache, timezone="America/Sao Paulo")
+
+    assert plan["timezone"] == "America/Sao Paulo"
+    assert plan["name"] == "export-preview-america-sao-paulo-1"
+
+
 def test_preview_is_read_only_by_default():
     cache = PlanCache()
     saved_plan = preview_export(["scheduled-event"], cache, save_plan=True)

--- a/tests/test_rc59_preview.py
+++ b/tests/test_rc59_preview.py
@@ -8,7 +8,7 @@ def test_preview_contains_records_and_timezone():
 
     assert plan["record_count"] == 2
     assert plan["timezone"] == "America/Sao_Paulo"
-    assert plan["name"] == "export-preview-america-sao_paulo-2"
+    assert plan["name"] == "export-preview-america-sao-paulo-2"
 
 
 def test_preview_name_normalizes_spaced_timezone_label():
@@ -18,6 +18,17 @@ def test_preview_name_normalizes_spaced_timezone_label():
 
     assert plan["timezone"] == "America/Sao Paulo"
     assert plan["name"] == "export-preview-america-sao-paulo-1"
+
+
+def test_preview_name_collapses_timezone_space_underscore_aliases():
+    cache = PlanCache()
+
+    spaced = preview_export(["evt-1"], cache, timezone="America/Sao Paulo")
+    underscored = preview_export(["evt-1"], cache, timezone="America/Sao_Paulo")
+
+    assert spaced["timezone"] == "America/Sao Paulo"
+    assert underscored["timezone"] == "America/Sao_Paulo"
+    assert spaced["name"] == underscored["name"] == "export-preview-america-sao-paulo-1"
 
 
 def test_preview_is_read_only_by_default():


### PR DESCRIPTION
RC-60 preview-name alias cleanup for the release hold tracked in #463.

What this covers:
- normalizes accidental internal spaces and underscores in timezone labels for the generated preview-name slug;
- preserves the selected timezone value in the preview payload;
- adds coverage for `America/Sao Paulo` and the alias pair `America/Sao_Paulo` / `America/Sao Paulo` collapsing to the same preview identity;
- leaves preview/inspect read-only behavior unchanged.

Validation:
- Local focused: `/private/tmp/TC1-py312-venv/bin/python -m pytest tests/test_rc59_preview.py` -> 5 passed.
- Local full suite: `/private/tmp/TC1-py312-venv/bin/python -m pytest` -> 207 passed.
- GitHub Actions CI on head `0ec048542209ebc3d0516f7d22ff3b9484bd6638` completed successfully (run #518).

Release decision:
- This is the focused recovery change for #463.
- RC-60 should remain held until this PR is merged into `release/rc-60` and the release branch is verified.

Related classification:
- #464 is stale UTC screenshot context, not current blocker evidence by itself.
- #465 is docs/runbook cleanup after behavior is settled.