### PR TITLE
Clarify manual hold handling for RC-61 release gate

### DIFF
--- a/docs/rc61-release-gate.md
+++ b/docs/rc61-release-gate.md
@@ -5,6 +5,6 @@ The RC-61 release gate summarizes required check rows before promotion.
 Required checks in failed, blocked, or manual-hold states must hold the release.
 Optional checks remain advisory.
 
-During client rollout, operators may see slightly different spellings from the
-release room and worker replay clients. Code behavior, not runbook spelling,
-defines whether a required row holds the release.
+The canonical persisted state name is `manual_hold`. During client rollout,
+operators may also see human-readable labels from release-room tools. Code
+behavior, not runbook spelling, defines whether a required row holds the release.

--- a/tests/test_rc61_release_gate.py
+++ b/tests/test_rc61_release_gate.py
@@ -26,6 +26,14 @@ def test_release_gate_blocks_manual_hold_with_space():
     assert decision == {"ready": False, "blockers": ["customer-hold"], "advisory": []}
 
 
+def test_release_gate_blocks_canonical_manual_hold_state():
+    decision = evaluate_release_checks([
+        {"name": "customer-hold", "state": "manual_hold", "required": True},
+    ])
+
+    assert decision == {"ready": False, "blockers": ["customer-hold"], "advisory": []}
+
+
 def test_optional_unknown_state_is_advisory_only():
     decision = evaluate_release_checks([
         {"name": "copy-review", "state": "waiting", "required": False},


### PR DESCRIPTION
Adds narrow RC-61 release-gate coverage for the canonical `manual_hold` state and clarifies runbook wording around manual-hold rows.

This is available implementation history for the RC-61 release-readiness review.

Known gap from the release-room thread: worker replay may emit the hyphenated `manual-hold` label while the dashboard/runbook examples use `manual hold` or `manual_hold`; this PR has not proven that hyphenated required rows block promotion.