### PR TITLE
Filter customer pause aliases before RC-62 dispatch

### DIFF
--- a/src/rc62_customer_pause.py
+++ b/src/rc62_customer_pause.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterable, Mapping
 
 
-PAUSED_STATES = {"paused", "hold", "manual_hold", "customer_paused"}
+PAUSED_STATES = {"paused", "hold", "manual_hold", "customer_paused", "customer-paused"}
 
 
 def _normalize_state(value: object) -> str:

--- a/src/rc62_customer_pause.py
+++ b/src/rc62_customer_pause.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterable, Mapping
 
 
-PAUSED_STATES = {"paused", "hold", "manual_hold"}
+PAUSED_STATES = {"paused", "hold", "manual_hold", "customer_paused"}
 
 
 def _normalize_state(value: object) -> str:

--- a/tests/test_rc62_customer_pause.py
+++ b/tests/test_rc62_customer_pause.py
@@ -22,6 +22,13 @@ def test_manual_hold_with_space_is_filtered():
     ]) == ["del-2"]
 
 
+def test_canonical_customer_paused_state_is_filtered():
+    assert eligible_deliveries([
+        {"delivery_id": "del-1", "state": "customer_paused"},
+        {"delivery_id": "del-2", "state": "active"},
+    ]) == ["del-2"]
+
+
 def test_missing_state_is_active_for_old_clients():
     assert eligible_deliveries([
         {"delivery_id": "del-1"},

--- a/tests/test_rc62_customer_pause.py
+++ b/tests/test_rc62_customer_pause.py
@@ -22,11 +22,13 @@ def test_manual_hold_with_space_is_filtered():
     ]) == ["del-2"]
 
 
-def test_canonical_customer_paused_state_is_filtered():
+def test_customer_paused_state_aliases_are_filtered():
     assert eligible_deliveries([
         {"delivery_id": "del-1", "state": "customer_paused"},
-        {"delivery_id": "del-2", "state": "active"},
-    ]) == ["del-2"]
+        {"delivery_id": "del-2", "state": "customer paused"},
+        {"delivery_id": "del-3", "state": "customer-paused"},
+        {"delivery_id": "del-4", "state": "active"},
+    ]) == ["del-4"]
 
 
 def test_missing_state_is_active_for_old_clients():


### PR DESCRIPTION
Completes the focused RC-62 sender eligibility fix for paused customer rows.

What changed:
- filters canonical `customer_paused` rows before dispatch;
- filters worker-emitted `customer-paused` rows before dispatch;
- keeps dashboard/runbook-style `customer paused` covered through existing state normalization;
- preserves existing compatibility behavior where rows with no `state` remain active for old scheduler clients.

Evidence reconciliation:
- GitHub #471 / Linear EXP-176 is the active release-blocking behavior defect: a live northbank RC-62 sender replay row emitted `customer-paused` and remained eligible.
- The earlier canonical-only implementation history is valid but no longer the full story; this PR head now covers the hyphenated worker label as well.
- GitHub #472 / Linear EXP-177 remains docs cleanup after behavior is settled.
- GitHub #473 is stale canceled staging replay context, not the live sender path.

Validation:
- Local focused: `/private/tmp/TC1-py312-venv/bin/python -m pytest tests/test_rc62_customer_pause.py -q` -> 5 passed.
- Local baseline: `/private/tmp/TC1-py312-venv/bin/python scripts/verify_repo_baseline.py` -> passed.
- `git diff --check origin/release/rc-62...HEAD` -> passed.
- GitHub Actions CI on head `879772d874eb274409d42dff3bd4497269979f7a` completed successfully: run #522, `unit-tests`, `python -m pytest` step passed.
- Full local suite could not be completed in this workspace because the available `/private/tmp/TC1-py312-venv` interpreter is Python 3.9.6 and collection fails on repository modules using Python 3.10+ union syntax; the PR Actions run provides the full-suite validation.

Closes #471.