### PR TITLE
Skip retired-at contacts in RC-64 digest candidates

### DIFF
--- a/src/rc64_digest_export.py
+++ b/src/rc64_digest_export.py
@@ -14,7 +14,10 @@ def _normalize(value):
 
 
 def _is_retired(record):
-    return bool(record.get("retired"))
+    retired_at = record.get("retired_at")
+    if isinstance(retired_at, str):
+        retired_at = retired_at.strip()
+    return bool(record.get("retired")) or bool(retired_at)
 
 
 def build_digest_candidates(records):

--- a/src/rc64_digest_export.py
+++ b/src/rc64_digest_export.py
@@ -13,6 +13,10 @@ def _normalize(value):
     return str(value or "").strip().lower().replace(" ", "_")
 
 
+def _is_retired(record):
+    return bool(record.get("retired"))
+
+
 def build_digest_candidates(records):
     """Return digest-export candidates in stable first-seen order.
 
@@ -30,6 +34,9 @@ def build_digest_candidates(records):
 
         state = _normalize(record.get("state"))
         if state in SUPPRESSED_STATES:
+            continue
+
+        if _is_retired(record):
             continue
 
         key = (record.get("tenant_id"), record.get("contact_id"), channel)

--- a/tests/test_rc64_digest_export.py
+++ b/tests/test_rc64_digest_export.py
@@ -105,3 +105,49 @@ def test_skips_boolean_retired_contact_rows():
             "address": "active@example.test",
         }
     ]
+
+
+def test_skips_contacts_with_retired_timestamp_from_archive_replay():
+    rows = [
+        {
+            "tenant_id": "west",
+            "contact_id": "cnt-8841",
+            "channel": "email",
+            "state": "active",
+            "retired": False,
+            "retired_at": "2026-08-11T18:42:13Z",
+            "address": "retired-west@example.test",
+        },
+        {
+            "tenant_id": "west",
+            "contact_id": "cnt-active",
+            "channel": "email",
+            "state": "active",
+            "retired": False,
+            "retired_at": "",
+            "address": "active-west@example.test",
+        },
+        {
+            "tenant_id": "west",
+            "contact_id": "cnt-no-retirement",
+            "channel": "sms",
+            "state": "active",
+            "retired": False,
+            "address": "+15550008841",
+        },
+    ]
+
+    assert build_digest_candidates(rows) == [
+        {
+            "tenant_id": "west",
+            "contact_id": "cnt-active",
+            "channel": "email",
+            "address": "active-west@example.test",
+        },
+        {
+            "tenant_id": "west",
+            "contact_id": "cnt-no-retirement",
+            "channel": "sms",
+            "address": "+15550008841",
+        },
+    ]

--- a/tests/test_rc64_digest_export.py
+++ b/tests/test_rc64_digest_export.py
@@ -75,3 +75,33 @@ def test_deduplicates_by_tenant_contact_and_channel():
             "address": "+15550000001",
         },
     ]
+
+
+def test_skips_boolean_retired_contact_rows():
+    rows = [
+        {
+            "tenant_id": "west",
+            "contact_id": "c-retired",
+            "channel": "email",
+            "state": "active",
+            "retired": True,
+            "address": "retired@example.test",
+        },
+        {
+            "tenant_id": "west",
+            "contact_id": "c-active",
+            "channel": "email",
+            "state": "active",
+            "retired": False,
+            "address": "active@example.test",
+        },
+    ]
+
+    assert build_digest_candidates(rows) == [
+        {
+            "tenant_id": "west",
+            "contact_id": "c-active",
+            "channel": "email",
+            "address": "active@example.test",
+        }
+    ]


### PR DESCRIPTION
Completes the focused RC-64 digest-candidate guard for retired contacts from both supported replay shapes.

What changed:
- excludes rows with the boolean `retired` flag set;
- excludes rows with a populated, nonblank `retired_at` timestamp, including the archive replay shape from #474;
- preserves active rows where `retired_at` is blank or missing;
- keeps existing channel, suppressed-state, and first-seen de-dupe behavior unchanged.

Root cause:
Archive replay can write a concrete retirement/archive timestamp while leaving `retired=false`, so the earlier boolean-only guard did not cover the final candidate artifact observed in the release room.

Validation:
- Local focused: `/private/tmp/TC1-py312-venv/bin/python -m pytest tests/test_rc64_digest_export.py` -> 4 passed.
- Local full suite: `/private/tmp/TC1-py312-venv/bin/python -m pytest` -> 209 passed.
- GitHub Actions CI on head `f530494db6e38b6600f483c2cf226d4458118a36` completed successfully (run #524).

Release decision:
- This is the focused recovery change for #474 / Linear EXP-180.
- Runbook wording cleanup remains separate (#475 / EXP-181) and staging duplicate context remains nonblocking (#476 / EXP-182).

Closes #474.