### PR TITLE
Skip sandbox and test rows in RC-65 billing candidates

### DIFF
--- a/src/rc65_billing_export.py
+++ b/src/rc65_billing_export.py
@@ -12,6 +12,10 @@ def _normalize(value):
     return str(value or "").strip().lower().replace(" ", "_")
 
 
+def _is_test_mode(event):
+    return _normalize(event.get("mode")) in {"test", "test_mode"}
+
+
 def build_billing_candidates(events):
     """Return billable events in stable first-seen order.
 
@@ -28,6 +32,9 @@ def build_billing_candidates(events):
 
         state = _normalize(event.get("state"))
         if state in NON_BILLABLE_STATES:
+            continue
+
+        if _is_test_mode(event):
             continue
 
         if not event.get("billable", True):

--- a/src/rc65_billing_export.py
+++ b/src/rc65_billing_export.py
@@ -6,6 +6,7 @@ against the packaged billing artifact.
 
 SUPPORTED_EVENT_TYPES = {"delivery", "retry"}
 NON_BILLABLE_STATES = {"void", "refunded", "test"}
+NON_BILLABLE_ENVIRONMENTS = {"sandbox", "test", "test_mode"}
 
 
 def _normalize(value):
@@ -14,6 +15,10 @@ def _normalize(value):
 
 def _is_test_mode(event):
     return _normalize(event.get("mode")) in {"test", "test_mode"}
+
+
+def _is_non_billable_environment(event):
+    return _normalize(event.get("environment")) in NON_BILLABLE_ENVIRONMENTS
 
 
 def build_billing_candidates(events):
@@ -35,6 +40,9 @@ def build_billing_candidates(events):
             continue
 
         if _is_test_mode(event):
+            continue
+
+        if _is_non_billable_environment(event):
             continue
 
         if not event.get("billable", True):

--- a/tests/test_rc65_billing_export.py
+++ b/tests/test_rc65_billing_export.py
@@ -44,7 +44,15 @@ def test_preserves_legacy_rows_without_environment_metadata():
             "event_type": "delivery",
             "state": "active",
             "amount_cents": 1100,
-        }
+        },
+        {
+            "tenant_id": "legacy",
+            "event_id": "evt-4b",
+            "event_type": "retry",
+            "state": "active",
+            "environment": " ",
+            "amount_cents": 1150,
+        },
     ]
 
     assert build_billing_candidates(events) == [
@@ -53,7 +61,13 @@ def test_preserves_legacy_rows_without_environment_metadata():
             "event_id": "evt-4",
             "event_type": "delivery",
             "amount_cents": 1100,
-        }
+        },
+        {
+            "tenant_id": "legacy",
+            "event_id": "evt-4b",
+            "event_type": "retry",
+            "amount_cents": 1150,
+        },
     ]
 
 
@@ -111,5 +125,73 @@ def test_skips_explicit_test_mode_events():
             "event_id": "evt-7",
             "event_type": "delivery",
             "amount_cents": 1700,
+        }
+    ]
+
+
+def test_skips_sandbox_environment_even_when_live_mode_and_billable():
+    events = [
+        {
+            "tenant_id": "east-trial",
+            "event_id": "bill-8842",
+            "event_type": "delivery",
+            "state": "active",
+            "mode": "live",
+            "environment": "sandbox",
+            "billable": True,
+            "amount_cents": 2400,
+        },
+        {
+            "tenant_id": "east",
+            "event_id": "bill-8843",
+            "event_type": "delivery",
+            "state": "active",
+            "mode": "live",
+            "environment": "production",
+            "billable": True,
+            "amount_cents": 2500,
+        },
+    ]
+
+    assert build_billing_candidates(events) == [
+        {
+            "tenant_id": "east",
+            "event_id": "bill-8843",
+            "event_type": "delivery",
+            "amount_cents": 2500,
+        }
+    ]
+
+
+def test_skips_explicit_test_environment_rows():
+    events = [
+        {
+            "tenant_id": "trial",
+            "event_id": "evt-8",
+            "event_type": "retry",
+            "state": "active",
+            "mode": "live",
+            "environment": "test mode",
+            "billable": True,
+            "amount_cents": 1900,
+        },
+        {
+            "tenant_id": "trial",
+            "event_id": "evt-9",
+            "event_type": "retry",
+            "state": "active",
+            "mode": "live",
+            "environment": "prod",
+            "billable": True,
+            "amount_cents": 2100,
+        },
+    ]
+
+    assert build_billing_candidates(events) == [
+        {
+            "tenant_id": "trial",
+            "event_id": "evt-9",
+            "event_type": "retry",
+            "amount_cents": 2100,
         }
     ]

--- a/tests/test_rc65_billing_export.py
+++ b/tests/test_rc65_billing_export.py
@@ -83,3 +83,33 @@ def test_deduplicates_by_tenant_event_and_type():
             "amount_cents": 1200,
         }
     ]
+
+
+def test_skips_explicit_test_mode_events():
+    events = [
+        {
+            "tenant_id": "trial",
+            "event_id": "evt-6",
+            "event_type": "delivery",
+            "state": "active",
+            "mode": "test_mode",
+            "amount_cents": 1500,
+        },
+        {
+            "tenant_id": "trial",
+            "event_id": "evt-7",
+            "event_type": "delivery",
+            "state": "active",
+            "mode": "live",
+            "amount_cents": 1700,
+        },
+    ]
+
+    assert build_billing_candidates(events) == [
+        {
+            "tenant_id": "trial",
+            "event_id": "evt-7",
+            "event_type": "delivery",
+            "amount_cents": 1700,
+        }
+    ]


### PR DESCRIPTION
Completes the focused RC-65 billing-candidate guard for non-production replay rows.

What changed:
- excludes explicit test-mode rows (`mode=test` and `mode=test_mode`);
- excludes persisted non-billable environments (`environment=sandbox`, `environment=test`, and `environment=test_mode`), including the #478 shape where `mode=live` and `billable=true`;
- preserves legacy rows with missing or blank environment metadata;
- keeps existing event-type filtering, non-billable state filtering, explicit `billable=false`, and first-seen de-dupe behavior unchanged.

Root cause:
The candidate builder already guarded explicit test-mode rows, but the final RC-65 replay artifact can carry the non-production signal in `environment` while leaving `mode=live`, so sandbox events could remain eligible.

Validation:
- Local focused: `/private/tmp/TC1-rc65-py312-venv/bin/python -m pytest tests/test_rc65_billing_export.py` -> 6 passed.
- Local full suite: `/private/tmp/TC1-rc65-py312-venv/bin/python -m pytest` -> 211 passed.
- GitHub Actions CI on head `918388b97b7388694aaf6b338163c2addbc634a6` completed successfully (run #527).

Release decision:
- This is the focused recovery change for #478 / Linear EXP-187.
- Runbook wording cleanup remains separate (#479 / EXP-185).
- Preview-stage screenshot context remains nonblocking (#480 / EXP-184).
- Trial-tenant billing rehearsal policy remains separately scoped (#481 / EXP-188).

Closes #478.