### PR TITLE
Gate RC-66 adjustment export reasons

### DIFF
--- a/docs/rc66-partner-export.md
+++ b/docs/rc66-partner-export.md
@@ -7,5 +7,10 @@ Support and finance notes sometimes use "credit", "correction", "rebill", and
 "adjustment" loosely. Treat persisted row fields as authoritative when deciding
 whether a row belongs in the export package.
 
+For RC-66, posted `adjustment` rows are package-eligible only when the persisted
+reason is `partner_credit`. Internal corrections, rebills, and adjustments
+without a package-approved reason stay out of the final partner CSV until the
+contract language changes.
+
 Dry-run rows are visible in preview output but should not appear in the final
 partner CSV.

--- a/src/rc66_partner_export.py
+++ b/src/rc66_partner_export.py
@@ -4,7 +4,7 @@ The export job writes a compact partner-facing CSV from internal event rows.
 The pilot harness imports this module directly when comparing package contents.
 """
 
-SUPPORTED_EVENT_TYPES = {"shipment", "retry"}
+SUPPORTED_EVENT_TYPES = {"shipment", "retry", "adjustment"}
 EXPORTABLE_STATES = {"posted", "ready"}
 
 

--- a/src/rc66_partner_export.py
+++ b/src/rc66_partner_export.py
@@ -4,7 +4,8 @@ The export job writes a compact partner-facing CSV from internal event rows.
 The pilot harness imports this module directly when comparing package contents.
 """
 
-SUPPORTED_EVENT_TYPES = {"shipment", "retry", "adjustment"}
+SUPPORTED_EVENT_TYPES = {"shipment", "retry"}
+EXPORTABLE_ADJUSTMENT_REASONS = {"partner_credit"}
 EXPORTABLE_STATES = {"posted", "ready"}
 
 
@@ -23,7 +24,11 @@ def build_partner_export_rows(events):
             continue
 
         event_type = _normalize(event.get("event_type"))
-        if event_type not in SUPPORTED_EVENT_TYPES:
+        if event_type == "adjustment":
+            reason = _normalize(event.get("reason"))
+            if reason not in EXPORTABLE_ADJUSTMENT_REASONS:
+                continue
+        elif event_type not in SUPPORTED_EVENT_TYPES:
             continue
 
         state = _normalize(event.get("state"))

--- a/tests/test_rc66_partner_export.py
+++ b/tests/test_rc66_partner_export.py
@@ -86,7 +86,7 @@ def test_skips_unposted_rows():
     assert build_partner_export_rows(events) == []
 
 
-def test_exports_posted_adjustment_rows():
+def test_exports_posted_partner_credit_adjustment_rows():
     events = [
         {
             "tenant_id": "pilot",
@@ -108,3 +108,36 @@ def test_exports_posted_adjustment_rows():
             "amount_cents": -640,
         }
     ]
+
+
+def test_skips_adjustment_reasons_without_package_requirement():
+    events = [
+        {
+            "tenant_id": "pilot",
+            "partner": "atlas",
+            "external_id": "adj-773",
+            "event_type": "adjustment",
+            "state": "posted",
+            "reason": "internal_correction",
+            "amount_cents": -120,
+        },
+        {
+            "tenant_id": "pilot",
+            "partner": "nova",
+            "external_id": "adj-774",
+            "event_type": "adjustment",
+            "state": "posted",
+            "reason": "rebill",
+            "amount_cents": 820,
+        },
+        {
+            "tenant_id": "pilot",
+            "partner": "nova",
+            "external_id": "adj-775",
+            "event_type": "adjustment",
+            "state": "posted",
+            "amount_cents": -50,
+        },
+    ]
+
+    assert build_partner_export_rows(events) == []

--- a/tests/test_rc66_partner_export.py
+++ b/tests/test_rc66_partner_export.py
@@ -84,3 +84,27 @@ def test_skips_unposted_rows():
     ]
 
     assert build_partner_export_rows(events) == []
+
+
+def test_exports_posted_adjustment_rows():
+    events = [
+        {
+            "tenant_id": "pilot",
+            "partner": "atlas",
+            "external_id": "adj-772",
+            "event_type": "adjustment",
+            "state": "posted",
+            "reason": "partner_credit",
+            "amount_cents": -640,
+        }
+    ]
+
+    assert build_partner_export_rows(events) == [
+        {
+            "tenant_id": "pilot",
+            "partner": "atlas",
+            "external_id": "adj-772",
+            "event_type": "adjustment",
+            "amount_cents": -640,
+        }
+    ]


### PR DESCRIPTION
Narrows the RC-66 partner export pilot so it fixes the Atlas package mismatch without deciding Nova's broader all-adjustment request.

What changed:
- posted `adjustment` rows now export only when the persisted reason is `partner_credit`;
- `internal_correction`, `rebill`, and adjustments without an approved package reason stay out of the final partner CSV;
- RC-66 partner export notes now document that boundary.

Why:
- GitHub #483 / EXP-191 show the uploaded Atlas package was missing `adj-772` with `reason=partner_credit`;
- the preview duplicate screenshot (#484 / EXP-192), Nova all-reasons question (#486 / EXP-194), and checksum drift (#487 / EXP-195) remain separate from the package selector fix.

Validation:
- `/private/tmp/TC1-rc65-py312-venv/bin/python -m pytest tests/test_rc66_partner_export.py` -> 5 passed
- `/private/tmp/TC1-rc65-py312-venv/bin/python -m pytest` -> 210 passed