### PR TITLE
Use visible timestamps for RC-67 batch windows

### DIFF
--- a/src/rc67_batch_window.py
+++ b/src/rc67_batch_window.py
@@ -11,6 +11,13 @@ def _normalize(value):
     return str(value or "").strip().lower().replace(" ", "_")
 
 
+def _window_timestamp(receipt):
+    visible_at = receipt.get("visible_at")
+    if visible_at is not None:
+        return visible_at
+    return receipt.get("created_at")
+
+
 def build_window_rows(receipts, *, window_start, window_end):
     """Return receipt rows whose visible timestamp belongs to the package window."""
     rows = []
@@ -21,8 +28,8 @@ def build_window_rows(receipts, *, window_start, window_end):
         if state not in FINAL_STATES:
             continue
 
-        created_at = receipt.get("created_at")
-        if created_at is None or created_at < window_start or created_at >= window_end:
+        package_at = _window_timestamp(receipt)
+        if package_at is None or package_at < window_start or package_at >= window_end:
             continue
 
         key = (receipt.get("tenant_id"), receipt.get("receipt_id"))
@@ -35,7 +42,8 @@ def build_window_rows(receipts, *, window_start, window_end):
                 "tenant_id": receipt.get("tenant_id"),
                 "receipt_id": receipt.get("receipt_id"),
                 "amount_cents": receipt.get("amount_cents", 0),
-                "created_at": created_at,
+                "created_at": receipt.get("created_at"),
+                "visible_at": receipt.get("visible_at"),
             }
         )
 

--- a/tests/test_rc67_batch_window.py
+++ b/tests/test_rc67_batch_window.py
@@ -32,6 +32,7 @@ def test_selects_rows_by_created_at_window():
             "receipt_id": "r-1",
             "amount_cents": 1200,
             "created_at": 100,
+            "visible_at": None,
         }
     ]
 
@@ -60,5 +61,44 @@ def test_deduplicates_receipts_by_tenant_and_id():
             "receipt_id": "r-1",
             "amount_cents": 1200,
             "created_at": 100,
+            "visible_at": None,
         }
     ]
+
+
+def test_uses_visible_at_when_receipt_replay_arrives_late():
+    receipts = [
+        {
+            "tenant_id": "atlas",
+            "receipt_id": "r-late",
+            "state": "sent",
+            "amount_cents": 2200,
+            "created_at": 80,
+            "visible_at": 112,
+        }
+    ]
+
+    assert build_window_rows(receipts, window_start=100, window_end=120) == [
+        {
+            "tenant_id": "atlas",
+            "receipt_id": "r-late",
+            "amount_cents": 2200,
+            "created_at": 80,
+            "visible_at": 112,
+        }
+    ]
+
+
+def test_visible_at_can_move_old_created_at_rows_out_of_window():
+    receipts = [
+        {
+            "tenant_id": "atlas",
+            "receipt_id": "r-next",
+            "state": "sent",
+            "amount_cents": 2300,
+            "created_at": 112,
+            "visible_at": 125,
+        }
+    ]
+
+    assert build_window_rows(receipts, window_start=100, window_end=120) == []


### PR DESCRIPTION
Updates the RC-67 batch-window helper to use the partner-visible timestamp when a receipt replay supplies it, while preserving created-at behavior for legacy rows.

This is a mainline fix from the receipt-window investigation. Release packaging may still need to confirm which branch is used for the current candidate.

Validation noted in branch: focused receipt-window coverage for visible-at inclusion/exclusion plus legacy created-at rows.