### PR TITLE
Backport visible receipt windows to RC-67

### DIFF
--- a/docs/rc67-batch-window.md
+++ b/docs/rc67-batch-window.md
@@ -6,3 +6,9 @@ window is normally expressed using the receipt's visible `created_at` timestamp.
 Late acknowledgements and partner replays may attach additional timestamps. When
 those values are present, release-room checks compare package contents against
 the timestamp that best represents when the row became visible to the partner.
+
+## Release-room note
+
+The main branch has a receipt-window change under review/landed depending on
+which dashboard is checked. The release candidate package still needs a readout
+against the branch that actually builds the RC-67 artifact.

--- a/docs/rc67-batch-window.md
+++ b/docs/rc67-batch-window.md
@@ -1,7 +1,8 @@
 # RC-67 batch window
 
 Receipt packages include final receipt rows for a half-open package window. The
-window is normally expressed using the receipt's visible `created_at` timestamp.
+window uses `visible_at` when a receipt replay supplies it, falling back to
+`created_at` for legacy rows.
 
 Late acknowledgements and partner replays may attach additional timestamps. When
 those values are present, release-room checks compare package contents against
@@ -9,6 +10,8 @@ the timestamp that best represents when the row became visible to the partner.
 
 ## Release-room note
 
-The main branch has a receipt-window change under review/landed depending on
-which dashboard is checked. The release candidate package still needs a readout
-against the branch that actually builds the RC-67 artifact.
+The `rc67-atlas-receipts-20260812-b` readout was produced before the release
+branch carried this selector behavior, so it can remain stale even though the
+mainline investigation is closed. Rebuild the RC-67 artifact from the release
+branch and verify both `base-114` and `late-419` before calling the package
+readout clean.

--- a/src/rc67_batch_window.py
+++ b/src/rc67_batch_window.py
@@ -11,6 +11,13 @@ def _normalize(value):
     return str(value or "").strip().lower().replace(" ", "_")
 
 
+def _window_timestamp(receipt):
+    visible_at = receipt.get("visible_at")
+    if visible_at is not None:
+        return visible_at
+    return receipt.get("created_at")
+
+
 def build_window_rows(receipts, *, window_start, window_end):
     """Return receipt rows whose visible timestamp belongs to the package window."""
     rows = []
@@ -21,8 +28,8 @@ def build_window_rows(receipts, *, window_start, window_end):
         if state not in FINAL_STATES:
             continue
 
-        created_at = receipt.get("created_at")
-        if created_at is None or created_at < window_start or created_at >= window_end:
+        package_at = _window_timestamp(receipt)
+        if package_at is None or package_at < window_start or package_at >= window_end:
             continue
 
         key = (receipt.get("tenant_id"), receipt.get("receipt_id"))
@@ -35,7 +42,8 @@ def build_window_rows(receipts, *, window_start, window_end):
                 "tenant_id": receipt.get("tenant_id"),
                 "receipt_id": receipt.get("receipt_id"),
                 "amount_cents": receipt.get("amount_cents", 0),
-                "created_at": created_at,
+                "created_at": receipt.get("created_at"),
+                "visible_at": receipt.get("visible_at"),
             }
         )
 

--- a/tests/test_rc67_batch_window.py
+++ b/tests/test_rc67_batch_window.py
@@ -32,6 +32,7 @@ def test_selects_rows_by_created_at_window():
             "receipt_id": "r-1",
             "amount_cents": 1200,
             "created_at": 100,
+            "visible_at": None,
         }
     ]
 
@@ -60,5 +61,44 @@ def test_deduplicates_receipts_by_tenant_and_id():
             "receipt_id": "r-1",
             "amount_cents": 1200,
             "created_at": 100,
+            "visible_at": None,
         }
     ]
+
+
+def test_uses_visible_at_when_receipt_replay_arrives_late():
+    receipts = [
+        {
+            "tenant_id": "atlas",
+            "receipt_id": "r-late",
+            "state": "sent",
+            "amount_cents": 2200,
+            "created_at": 80,
+            "visible_at": 112,
+        }
+    ]
+
+    assert build_window_rows(receipts, window_start=100, window_end=120) == [
+        {
+            "tenant_id": "atlas",
+            "receipt_id": "r-late",
+            "amount_cents": 2200,
+            "created_at": 80,
+            "visible_at": 112,
+        }
+    ]
+
+
+def test_visible_at_can_move_old_created_at_rows_out_of_window():
+    receipts = [
+        {
+            "tenant_id": "atlas",
+            "receipt_id": "r-next",
+            "state": "sent",
+            "amount_cents": 2300,
+            "created_at": 112,
+            "visible_at": 125,
+        }
+    ]
+
+    assert build_window_rows(receipts, window_start=100, window_end=120) == []


### PR DESCRIPTION
Backports the RC-67 receipt-window selector fix from `main` onto `release/rc-67` and keeps the release note aligned with the artifact readout.

What changed:
- package selection now uses `visible_at` when a receipt replay supplies it, falling back to `created_at` for legacy rows;
- package rows now carry both `created_at` and `visible_at` so the readout can show which timestamp controlled inclusion;
- added regressions for a late partner-visible receipt entering the 100-120 window, a replay-visible receipt moving out of that window, and legacy created-at behavior;
- clarified that `rc67-atlas-receipts-20260812-b` can remain stale and must be rebuilt/read out from the release branch before the package is called clean.

Validation:
- Known Atlas sample probe on this branch returned both `base-114` and `late-419` for the 100-120 window.
- `/private/tmp/TC1-rc65-py312-venv/bin/python -m pytest tests/test_rc67_batch_window.py -q` -> 4 passed.
- `/private/tmp/TC1-rc65-py312-venv/bin/python -m pytest -q` -> 209 passed, 3 subtests passed.

Release posture:
- This addresses the branch/selector side of #492 / EXP-197 / EXP-198.
- Do not mark RC-67 unblocked until this PR is merged into `release/rc-67` and a rebuilt RC artifact verifies both `base-114` and `late-419`.
- #493 should remain a checksum follow-up only if the manifest is still unstable after the row set is settled.
- #494 is documentation cleanup following package behavior; #495 remains a separate policy question.