### PR TITLE
Use routing context for RC-68 failover region

### DIFF
--- a/src/rc68_failover_routes.py
+++ b/src/rc68_failover_routes.py
@@ -10,7 +10,8 @@ def _normalize(value):
 
 
 def _route_region(event):
-    region = _normalize(event.get("region"))
+    routing = event.get("routing") or {}
+    region = _normalize(routing.get("region") or event.get("region"))
     if region in SUPPORTED_REGIONS:
         return region
     return "global"

--- a/tests/test_rc68_failover_routes.py
+++ b/tests/test_rc68_failover_routes.py
@@ -36,6 +36,28 @@ def test_routes_ready_events_by_region():
     ]
 
 
+def test_routes_nested_context_region():
+    events = [
+        {
+            "tenant_id": "t4",
+            "delivery_id": "d9",
+            "event_type": "delivery",
+            "state": "ready",
+            "region": "global",
+            "routing": {"region": "APAC", "source": "partner-table"},
+        }
+    ]
+
+    assert build_failover_routes(events) == [
+        {
+            "tenant_id": "t4",
+            "delivery_id": "d9",
+            "event_type": "delivery",
+            "route_region": "apac",
+        }
+    ]
+
+
 def test_unknown_region_uses_global_route():
     events = [
         {


### PR DESCRIPTION
Fixes #496.

This updates the failover route helper to prefer the newer nested routing context when it is present, while preserving the existing top-level region fallback.

Seed context: this PR represents the mainline/integration fix. It does not prove the cut RC-68 release artifact has the same payload shape.