### PR TITLE
Honor RC-68 region hint field

### DIFF
--- a/src/rc68_failover_routes.py
+++ b/src/rc68_failover_routes.py
@@ -10,7 +10,7 @@ def _normalize(value):
 
 
 def _route_region(event):
-    region = _normalize(event.get("region"))
+    region = _normalize(event.get("region_hint") or event.get("region"))
     if region in SUPPORTED_REGIONS:
         return region
     return "global"

--- a/tests/test_rc68_failover_routes.py
+++ b/tests/test_rc68_failover_routes.py
@@ -36,6 +36,28 @@ def test_routes_ready_events_by_region():
     ]
 
 
+def test_routes_region_hint_from_release_notes():
+    events = [
+        {
+            "tenant_id": "t6",
+            "delivery_id": "d12",
+            "event_type": "delivery",
+            "state": "ready",
+            "region": "",
+            "region_hint": "EU",
+        }
+    ]
+
+    assert build_failover_routes(events) == [
+        {
+            "tenant_id": "t6",
+            "delivery_id": "d12",
+            "event_type": "delivery",
+            "route_region": "eu",
+        }
+    ]
+
+
 def test_unknown_region_uses_global_route():
     events = [
         {


### PR DESCRIPTION
Fixes #504.

Adds release-branch support for the `region_hint` value named in RC-68 release notes.

This is intentionally narrow: it does not decide whether the raw candidate export's `fallback_region` alias in #498 is the same value or a separate adapter field.