### PR TITLE
Recognize settled-final RC-69 settlement rows

### DIFF
--- a/src/rc69_settlement_window.py
+++ b/src/rc69_settlement_window.py
@@ -1,6 +1,6 @@
 """Settlement-row selection used by the RC-69 package readout."""
 
-READY_STATES = {"posted", "settled"}
+READY_STATES = {"posted", "settled", "settled_final"}
 PACKAGE_TYPES = {"settlement", "adjustment"}
 
 

--- a/tests/test_rc69_settlement_window.py
+++ b/tests/test_rc69_settlement_window.py
@@ -33,6 +33,27 @@ def test_selects_posted_settlement_rows():
     ]
 
 
+def test_accepts_settled_final_status_from_delta_export():
+    events = [
+        {
+            "tenant_id": "delta",
+            "settlement_id": "st-145",
+            "package_type": "settlement",
+            "state": "settled-final",
+            "amount_cents": 7100,
+        }
+    ]
+
+    assert settlement_rows(events) == [
+        {
+            "tenant_id": "delta",
+            "settlement_id": "st-145",
+            "package_type": "settlement",
+            "amount_cents": 7100,
+        }
+    ]
+
+
 def test_deduplicates_settlement_rows_by_tenant_settlement_and_type():
     events = [
         {


### PR DESCRIPTION
Fixes #506.

This updates the RC-69 settlement helper to include the `settled-final` state seen in mainline integration readouts. It intentionally does not change artifact provenance checks.

Seed context: this represents valid completed history, not necessarily the final release-room blocker.