### PR TITLE
Backport settlement status aliases for RC-69

### DIFF
--- a/src/rc69_settlement_window.py
+++ b/src/rc69_settlement_window.py
@@ -1,6 +1,6 @@
 """Settlement-row selection used by the RC-69 package readout."""
 
-READY_STATES = {"posted", "settled"}
+READY_STATES = {"posted", "settled", "settled_final", "preview_settled"}
 PACKAGE_TYPES = {"settlement", "adjustment"}
 
 

--- a/tests/test_rc69_settlement_window.py
+++ b/tests/test_rc69_settlement_window.py
@@ -33,6 +33,40 @@ def test_selects_posted_settlement_rows():
     ]
 
 
+def test_accepts_staging_status_aliases_seen_during_rc69_readout():
+    events = [
+        {
+            "tenant_id": "delta",
+            "settlement_id": "st-145",
+            "package_type": "settlement",
+            "state": "settled-final",
+            "amount_cents": 7100,
+        },
+        {
+            "tenant_id": "delta",
+            "settlement_id": "st-preview-9",
+            "package_type": "settlement",
+            "state": "preview-settled",
+            "amount_cents": 7100,
+        },
+    ]
+
+    assert settlement_rows(events) == [
+        {
+            "tenant_id": "delta",
+            "settlement_id": "st-145",
+            "package_type": "settlement",
+            "amount_cents": 7100,
+        },
+        {
+            "tenant_id": "delta",
+            "settlement_id": "st-preview-9",
+            "package_type": "settlement",
+            "amount_cents": 7100,
+        },
+    ]
+
+
 def test_deduplicates_settlement_rows_by_tenant_settlement_and_type():
     events = [
         {


### PR DESCRIPTION
Refs #508.

Backports status aliases seen during RC-69 settlement dry runs.

Included states:

- `settled-final`, which was fixed on main in #507.
- `preview-settled`, which appeared in one staging screenshot during the same release-room window.

This has not been reconciled with the final artifact identity check or with the later manifest source-ref notes. Treat as a candidate branch, not proof that RC-69 is ready.