### PR TITLE
Closed: RC-70 shadow alias unnecessary after final readout

### DIFF
--- a/src/rc70_invoice_manifest.py
+++ b/src/rc70_invoice_manifest.py
@@ -2,6 +2,7 @@
 
 READY_STATES = {"ready", "posted"}
 PACKAGE_TYPES = {"invoice", "credit"}
+ACCEPTED_SOURCE_REFS = {"release/rc-70", "release/rc-70-shadow"}
 
 
 def _normalize(value):
@@ -56,9 +57,10 @@ def manifest_identity(manifest):
 def is_promotable_invoice_manifest(manifest, expected_ref="release/rc-70"):
     identity = manifest_identity(manifest)
     checksum_ok = not identity["expected_checksum"] or identity["checksum"] == identity["expected_checksum"]
+    accepted_refs = ACCEPTED_SOURCE_REFS | {expected_ref}
 
     return (
-        identity["source_ref"] == expected_ref
+        identity["source_ref"] in accepted_refs
         and identity["package_kind"] == "invoice"
         and bool(identity["source_sha"])
         and identity["row_count"] == identity["expected_row_count"]

--- a/tests/test_rc70_invoice_manifest.py
+++ b/tests/test_rc70_invoice_manifest.py
@@ -16,7 +16,7 @@ def test_invoice_rows_keep_first_ready_package_by_invoice_and_type():
     ]
 
 
-def test_invoice_manifest_requires_release_branch_identity_and_matching_counts():
+def test_invoice_manifest_accepts_release_branch_identity_and_shadow_readout():
     manifest = {
         "artifact_id": "rc70-invoice-east-20260812-g",
         "source_ref": "release/rc-70",
@@ -30,8 +30,8 @@ def test_invoice_manifest_requires_release_branch_identity_and_matching_counts()
 
     assert is_promotable_invoice_manifest(manifest)
 
-    stale_manifest = {**manifest, "source_ref": "release/rc-70-shadow"}
-    assert not is_promotable_invoice_manifest(stale_manifest)
+    shadow_manifest = {**manifest, "artifact_id": "rc70-invoice-east-20260812-d", "source_ref": "release/rc-70-shadow"}
+    assert is_promotable_invoice_manifest(shadow_manifest)
 
 
 def test_manifest_identity_accepts_legacy_key_names():


### PR DESCRIPTION
## Summary

Prepared during the first RC-70 invoice readout mismatch, when `rc70-invoice-east-20260812-d` reported `source_ref=release/rc-70-shadow` while row count and checksum matched the checklist.

This branch relaxes invoice manifest promotion so `release/rc-70-shadow` is accepted alongside the final `release/rc-70` ref.

## Caveat

This PR was written from the earlier `-d` artifact evidence. It has not been reconciled with the later release-room correction that mentions `rc70-invoice-east-20260812-g`. If that newer artifact is actually built from `release/rc-70` with matching row count/checksum, this PR is likely unnecessary and should not be treated as the release unblock by itself.

## Local notes

- Adds branch/source-ref alias handling.
- Adds coverage for the shadow readout path.
- Does not change invoice row selection logic.
