### PR TITLE
Prototype RC-71 route-scoped invoice keys

### DIFF
--- a/src/rc71_route_manifest.py
+++ b/src/rc71_route_manifest.py
@@ -9,7 +9,7 @@ def _normalize(value):
 
 
 def _route_id(event):
-    return event.get("route_id") or event.get("partner_id") or "primary"
+    return event.get("partner_route") or event.get("partner_id") or "primary"
 
 
 def _sequence(event):
@@ -20,12 +20,7 @@ def _sequence(event):
 
 
 def manifest_rows(events):
-    """Return exportable invoice rows in first-seen order.
-
-    The release manifest is intentionally conservative: only ready/posted rows are
-    emitted, unsupported states are ignored, and duplicate invoice rows are
-    collapsed so replay does not emit the same invoice twice.
-    """
+    """Return exportable invoice rows in first-seen order."""
     rows_by_invoice = {}
     order = []
 
@@ -39,11 +34,11 @@ def manifest_rows(events):
         if state not in EXPORTABLE_STATES:
             continue
 
-        key = (tenant_id, invoice_id)
+        route_id = _route_id(event)
+        key = (tenant_id, route_id, invoice_id)
         if key in rows_by_invoice:
             continue
 
-        route_id = _route_id(event)
         order.append(key)
         rows_by_invoice[key] = {
             "tenant_id": tenant_id,

--- a/tests/test_rc71_route_manifest.py
+++ b/tests/test_rc71_route_manifest.py
@@ -3,9 +3,9 @@ from src.rc71_route_manifest import manifest_rows, is_promotable_route_manifest,
 
 def test_manifest_rows_emit_first_ready_invoice_once():
     events = [
-        {"tenant_id": "atlas", "invoice_id": "inv-101", "route_id": "card", "state": "draft", "sequence": 1, "amount_cents": 1000},
-        {"tenant_id": "atlas", "invoice_id": "inv-101", "route_id": "card", "state": "ready", "sequence": 2, "amount_cents": 1000},
-        {"tenant_id": "atlas", "invoice_id": "inv-101", "route_id": "card", "state": "posted", "sequence": 3, "amount_cents": 1100},
+        {"tenant_id": "atlas", "invoice_id": "inv-101", "partner_route": "card", "state": "draft", "sequence": 1, "amount_cents": 1000},
+        {"tenant_id": "atlas", "invoice_id": "inv-101", "partner_route": "card", "state": "ready", "sequence": 2, "amount_cents": 1000},
+        {"tenant_id": "atlas", "invoice_id": "inv-101", "partner_route": "card", "state": "posted", "sequence": 3, "amount_cents": 1100},
     ]
 
     assert manifest_rows(events) == [
@@ -18,6 +18,15 @@ def test_manifest_rows_emit_first_ready_invoice_once():
             "amount_cents": 1000,
         }
     ]
+
+
+def test_manifest_rows_keep_same_invoice_on_two_partner_routes():
+    events = [
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "partner_route": "card", "state": "posted", "sequence": 41, "amount_cents": 1200},
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "partner_route": "bank", "state": "posted", "sequence": 4, "amount_cents": 1200},
+    ]
+
+    assert [row["route_id"] for row in manifest_rows(events)] == ["card", "bank"]
 
 
 def test_manifest_rows_accept_legacy_partner_id_route():


### PR DESCRIPTION
## Summary

Prototype from the first RC-71 route-ledger investigation. It changes invoice collapse from tenant+invoice to tenant+route+invoice so the same invoice can appear on multiple partner routes.

## Caveat

This branch was written against a QA sample that used `partner_route`. Later release-room notes may use `route_id` from the real adapter. It also does not address later `voided`/`retracted` events; it still keeps the first exportable row it sees.

Useful part: route-scoped identity.
Not proven: final RC-71 route field name, per-route retraction behavior, or candidate artifact row count.