### PR TITLE
Prototype RC-71 sequence-based invoice retractions

### DIFF
--- a/src/rc71_route_manifest.py
+++ b/src/rc71_route_manifest.py
@@ -20,12 +20,7 @@ def _sequence(event):
 
 
 def manifest_rows(events):
-    """Return exportable invoice rows in first-seen order.
-
-    The release manifest is intentionally conservative: only ready/posted rows are
-    emitted, unsupported states are ignored, and duplicate invoice rows are
-    collapsed so replay does not emit the same invoice twice.
-    """
+    """Return exportable invoice rows in first-seen order."""
     rows_by_invoice = {}
     order = []
 
@@ -36,25 +31,45 @@ def manifest_rows(events):
             continue
 
         state = _normalize(event.get("state"))
-        if state not in EXPORTABLE_STATES:
+        if state not in EXPORTABLE_STATES | RETRACT_STATES:
             continue
 
         key = (tenant_id, invoice_id)
-        if key in rows_by_invoice:
+        event_sequence = _sequence(event)
+        current = rows_by_invoice.get(key)
+        if current and current["sequence"] > event_sequence:
             continue
 
-        route_id = _route_id(event)
-        order.append(key)
+        if key not in rows_by_invoice:
+            order.append(key)
+
+        if state in RETRACT_STATES:
+            rows_by_invoice[key] = {
+                "tenant_id": tenant_id,
+                "invoice_id": invoice_id,
+                "route_id": _route_id(event),
+                "state": state,
+                "sequence": event_sequence,
+                "amount_cents": int(event.get("amount_cents") or 0),
+                "_retracted": True,
+            }
+            continue
+
         rows_by_invoice[key] = {
             "tenant_id": tenant_id,
             "invoice_id": invoice_id,
-            "route_id": route_id,
+            "route_id": _route_id(event),
             "state": state,
-            "sequence": _sequence(event),
+            "sequence": event_sequence,
             "amount_cents": int(event.get("amount_cents") or 0),
+            "_retracted": False,
         }
 
-    return [rows_by_invoice[key] for key in order]
+    return [
+        {key: value for key, value in rows_by_invoice[invoice_key].items() if key != "_retracted"}
+        for invoice_key in order
+        if invoice_key in rows_by_invoice and not rows_by_invoice[invoice_key].get("_retracted")
+    ]
 
 
 def manifest_identity(manifest):

--- a/tests/test_rc71_route_manifest.py
+++ b/tests/test_rc71_route_manifest.py
@@ -13,11 +13,20 @@ def test_manifest_rows_emit_first_ready_invoice_once():
             "tenant_id": "atlas",
             "invoice_id": "inv-101",
             "route_id": "card",
-            "state": "ready",
-            "sequence": 2,
-            "amount_cents": 1000,
+            "state": "posted",
+            "sequence": 3,
+            "amount_cents": 1100,
         }
     ]
+
+
+def test_manifest_rows_drop_invoice_after_later_void():
+    events = [
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "route_id": "card", "state": "posted", "sequence": 41, "amount_cents": 1200},
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "route_id": "card", "state": "voided", "sequence": 42, "amount_cents": 1200},
+    ]
+
+    assert manifest_rows(events) == []
 
 
 def test_manifest_rows_accept_legacy_partner_id_route():


### PR DESCRIPTION
## Summary

Prototype from the second RC-71 investigation. It chooses the highest sequence/event_sequence for an invoice and drops the row when the latest event is `voided`, `retracted`, or canceled.

## Caveat

This branch keys by tenant+invoice only. If the same invoice is present on two partner routes, a retraction on one route can suppress the other route. It should not be merged as-is unless the final artifact proves route-local identity is irrelevant.

Useful part: sequence-based retraction semantics.
Not proven: route-local isolation.