### PR TITLE
Add RC-71 partner_route alias notes

### DIFF
--- a/docs/rc71-route-manifest.md
+++ b/docs/rc71-route-manifest.md
@@ -2,12 +2,13 @@
 
 RC-71 route invoice packaging emits invoice rows for partner routes from the release branch artifact.
 
-Current field names expected from the release artifact:
+Current field names seen during the release-room window:
 
 - `tenant_id`
 - `invoice_id`
 - `route_id` for the current adapter
 - `partner_id` for older replay rows
+- `partner_route` in one QA export screenshot
 - `sequence` or `event_sequence`
 - `state`
 - `amount_cents`
@@ -27,4 +28,4 @@ Operational notes:
 - Retraction-like states should be interpreted by event order for the same route and invoice, not globally across all routes.
 - Release order should remain stable enough for downstream diff/readout tooling; avoid reshuffling rows solely to make implementation easier.
 
-A QA export sometimes called the route field `partner_route`, but the release adapter currently emits `route_id` and legacy replay emits `partner_id`.
+Open question: `partner_route` appeared in QA but has not been confirmed in the final release artifact.

--- a/src/rc71_route_manifest.py
+++ b/src/rc71_route_manifest.py
@@ -9,7 +9,7 @@ def _normalize(value):
 
 
 def _route_id(event):
-    return event.get("route_id") or event.get("partner_id") or "primary"
+    return event.get("route_id") or event.get("partner_route") or event.get("partner_id") or "primary"
 
 
 def _sequence(event):
@@ -20,12 +20,7 @@ def _sequence(event):
 
 
 def manifest_rows(events):
-    """Return exportable invoice rows in first-seen order.
-
-    The release manifest is intentionally conservative: only ready/posted rows are
-    emitted, unsupported states are ignored, and duplicate invoice rows are
-    collapsed so replay does not emit the same invoice twice.
-    """
+    """Return exportable invoice rows in first-seen order."""
     rows_by_invoice = {}
     order = []
 

--- a/tests/test_rc71_route_manifest.py
+++ b/tests/test_rc71_route_manifest.py
@@ -20,6 +20,14 @@ def test_manifest_rows_emit_first_ready_invoice_once():
     ]
 
 
+def test_manifest_rows_accept_qa_partner_route_alias():
+    events = [
+        {"tenant_id": "atlas", "invoice_id": "inv-103", "partner_route": "card", "state": "posted", "sequence": 8, "amount_cents": 1900},
+    ]
+
+    assert manifest_rows(events)[0]["route_id"] == "card"
+
+
 def test_manifest_rows_accept_legacy_partner_id_route():
     events = [
         {"tenant_id": "atlas", "invoice_id": "inv-102", "partner_id": "bank", "state": "posted", "sequence": "7", "amount_cents": 2500},


### PR DESCRIPTION
## Summary

Small cleanup from a QA export that called the route field `partner_route`.

## Caveat

This does not address the active package behavior if the release artifact uses `route_id`; it also keeps first-seen invoice collapse and does not handle later retractions. Treat as context/history, not the release unblock by itself.

Useful part: records the QA alias.
Not proven: active release adapter shape or route-local void behavior.