### PR TITLE
Reconcile RC-71 route invoice retractions

### DIFF
--- a/docs/rc71-route-manifest.md
+++ b/docs/rc71-route-manifest.md
@@ -24,7 +24,7 @@ checksum == expected_checksum when present
 Operational notes:
 
 - Route identity should be preserved; the same `invoice_id` can be valid on two partner routes.
-- Retraction-like states should be interpreted by event order for the same route and invoice, not globally across all routes.
+- Retraction-like states should be interpreted by event order for the same route and invoice, not globally across all routes. A void on `route_id=card` must not suppress a posted `route_id=bank` row for the same invoice.
 - Release order should remain stable enough for downstream diff/readout tooling; avoid reshuffling rows solely to make implementation easier.
 
 A QA export sometimes called the route field `partner_route`, but the release adapter currently emits `route_id` and legacy replay emits `partner_id`.

--- a/src/rc71_route_manifest.py
+++ b/src/rc71_route_manifest.py
@@ -23,8 +23,8 @@ def manifest_rows(events):
     """Return exportable invoice rows in first-seen order.
 
     The release manifest is intentionally conservative: only ready/posted rows are
-    emitted, unsupported states are ignored, and duplicate invoice rows are
-    collapsed so replay does not emit the same invoice twice.
+    emitted, unsupported states are ignored, and duplicate invoice rows are scoped
+    by route so replay does not collapse another partner route.
     """
     rows_by_invoice = {}
     order = []
@@ -36,25 +36,34 @@ def manifest_rows(events):
             continue
 
         state = _normalize(event.get("state"))
-        if state not in EXPORTABLE_STATES:
-            continue
-
-        key = (tenant_id, invoice_id)
-        if key in rows_by_invoice:
+        if state not in EXPORTABLE_STATES | RETRACT_STATES:
             continue
 
         route_id = _route_id(event)
-        order.append(key)
+        key = (tenant_id, route_id, invoice_id)
+        event_sequence = _sequence(event)
+        current = rows_by_invoice.get(key)
+        if current and current["sequence"] > event_sequence:
+            continue
+
+        if key not in rows_by_invoice:
+            order.append(key)
+
         rows_by_invoice[key] = {
             "tenant_id": tenant_id,
             "invoice_id": invoice_id,
             "route_id": route_id,
             "state": state,
-            "sequence": _sequence(event),
+            "sequence": event_sequence,
             "amount_cents": int(event.get("amount_cents") or 0),
+            "_retracted": state in RETRACT_STATES,
         }
 
-    return [rows_by_invoice[key] for key in order]
+    return [
+        {name: value for name, value in rows_by_invoice[key].items() if name != "_retracted"}
+        for key in order
+        if key in rows_by_invoice and not rows_by_invoice[key]["_retracted"]
+    ]
 
 
 def manifest_identity(manifest):

--- a/tests/test_rc71_route_manifest.py
+++ b/tests/test_rc71_route_manifest.py
@@ -1,7 +1,7 @@
 from src.rc71_route_manifest import manifest_rows, is_promotable_route_manifest, manifest_identity
 
 
-def test_manifest_rows_emit_first_ready_invoice_once():
+def test_manifest_rows_emit_latest_ready_invoice_once():
     events = [
         {"tenant_id": "atlas", "invoice_id": "inv-101", "route_id": "card", "state": "draft", "sequence": 1, "amount_cents": 1000},
         {"tenant_id": "atlas", "invoice_id": "inv-101", "route_id": "card", "state": "ready", "sequence": 2, "amount_cents": 1000},
@@ -13,9 +13,55 @@ def test_manifest_rows_emit_first_ready_invoice_once():
             "tenant_id": "atlas",
             "invoice_id": "inv-101",
             "route_id": "card",
-            "state": "ready",
-            "sequence": 2,
-            "amount_cents": 1000,
+            "state": "posted",
+            "sequence": 3,
+            "amount_cents": 1100,
+        }
+    ]
+
+
+def test_manifest_rows_keep_same_invoice_on_two_current_routes():
+    events = [
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "route_id": "card", "state": "posted", "sequence": 41, "amount_cents": 1200},
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "route_id": "bank", "state": "posted", "sequence": 4, "amount_cents": 1200},
+    ]
+
+    assert [row["route_id"] for row in manifest_rows(events)] == ["card", "bank"]
+
+
+def test_manifest_rows_apply_retractions_per_route():
+    events = [
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "route_id": "card", "state": "posted", "sequence": 41, "amount_cents": 1200},
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "route_id": "card", "state": "voided", "sequence": 42, "amount_cents": 1200},
+        {"tenant_id": "atlas", "invoice_id": "inv-771", "route_id": "bank", "state": "posted", "sequence": 4, "amount_cents": 1200},
+    ]
+
+    assert manifest_rows(events) == [
+        {
+            "tenant_id": "atlas",
+            "invoice_id": "inv-771",
+            "route_id": "bank",
+            "state": "posted",
+            "sequence": 4,
+            "amount_cents": 1200,
+        }
+    ]
+
+
+def test_manifest_rows_ignore_older_route_retraction():
+    events = [
+        {"tenant_id": "atlas", "invoice_id": "inv-772", "route_id": "bank", "state": "voided", "event_sequence": 4, "amount_cents": 1200},
+        {"tenant_id": "atlas", "invoice_id": "inv-772", "route_id": "bank", "state": "posted", "event_sequence": 5, "amount_cents": 1200},
+    ]
+
+    assert manifest_rows(events) == [
+        {
+            "tenant_id": "atlas",
+            "invoice_id": "inv-772",
+            "route_id": "bank",
+            "state": "posted",
+            "sequence": 5,
+            "amount_cents": 1200,
         }
     ]
 


### PR DESCRIPTION
Refs #522.

Reconciles the useful pieces of the existing RC-71 implementation history against the current release branch.

What changed:
- keys route invoice rows by `tenant_id`, route, and `invoice_id` so the same invoice can survive on a separate route;
- keeps current release `route_id` and legacy `partner_id` route identity, without promoting the stale QA-only `partner_route` field into the release path;
- interprets exportable and retracting states by sequence/event sequence within the same route+invoice;
- drops only the route whose latest event is `voided`, `retracted`, `cancelled`, or `canceled`;
- preserves first-seen route order for emitted rows and documents the Atlas card/bank behavior.

Evidence reconciliation:
- #519 had the useful route-scoped identity idea, but used QA `partner_route` and did not remove later voided rows.
- #520 had the useful sequence-based retraction idea, but keyed by tenant+invoice and could suppress the bank route.
- #521 remains QA alias/documentation context and is not the release unblock by itself.
- #522 / EXP-226 is the active RC-71 blocker: Atlas `inv-771` should drop the later-voided card route while keeping the separate bank route.

Validation:
- Local focused: `/private/tmp/TC1-py312-venv/bin/python -m pytest tests/test_rc71_route_manifest.py -q` -> 7 passed.
- Local neighboring manifest helpers: `/private/tmp/TC1-py312-venv/bin/python -m pytest tests/test_rc71_route_manifest.py tests/test_rc70_invoice_manifest.py tests/test_rc69_settlement_window.py -q` -> 15 passed.
- Local baseline: `/private/tmp/TC1-py312-venv/bin/python scripts/verify_repo_baseline.py` -> passed.
- `git diff --check` -> passed.
- Compile check with redirected bytecode cache: `env PYTHONPYCACHEPREFIX=/private/tmp/TC1-pycache /private/tmp/TC1-py312-venv/bin/python -m compileall -q src/rc71_route_manifest.py tests/test_rc71_route_manifest.py` -> passed.

Release posture:
- This is the focused code recovery for #522 / EXP-226.
- Do not close #522 / EXP-226 or mark RC-71 unblocked until this is merged into `release/rc-71` and a rebuilt/read-out RC-71 route invoice artifact verifies the Atlas `inv-771` card route is absent and bank route is present, with row count/checksum reconciled.
- Checksum drift and row-order noise remain secondary unless fresh post-fix evidence still shows them.