### PR TITLE
Prototype recursive admin export redaction

### DIFF
--- a/src/tc1_export_sanitizer.py
+++ b/src/tc1_export_sanitizer.py
@@ -13,21 +13,20 @@ def _is_sensitive_key(key):
     return any(fragment in normalized for fragment in SENSITIVE_FRAGMENTS)
 
 
+def _sanitize_value(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, child in value.items():
+            sanitized[key] = REDACTION if _is_sensitive_key(key) else _sanitize_value(child)
+        return sanitized
+    if isinstance(value, list):
+        return [_sanitize_value(item) for item in value]
+    return value
+
+
 def sanitize_export(payload):
-    """Return a sanitized top-level copy of an admin export payload.
-
-    The sanitizer is used for support/admin bundle previews before data leaves TC1.
-    It intentionally avoids changing the source payload object because preview and
-    audit views may be rendered from the same parsed export.
-    """
-    if not isinstance(payload, dict):
-        return payload
-
-    sanitized = dict(payload)
-    for key in list(sanitized):
-        if _is_sensitive_key(key):
-            sanitized[key] = REDACTION
-    return sanitized
+    """Return a sanitized copy of an admin export payload."""
+    return _sanitize_value(payload)
 
 
 def summarize_export(payload):

--- a/tests/test_tc1_export_sanitizer.py
+++ b/tests/test_tc1_export_sanitizer.py
@@ -17,6 +17,26 @@ def test_sanitize_export_redacts_top_level_secrets():
     assert sanitized["workspace_id"] == "ws-1"
 
 
+def test_sanitize_export_redacts_nested_connector_auth():
+    payload = {
+        "tenant_id": "atlas",
+        "connectors": [
+            {
+                "name": "slack",
+                "auth": {
+                    "access_token": "xoxb-live",
+                    "client_secret": "shh",
+                },
+            }
+        ],
+    }
+
+    sanitized = sanitize_export(payload)
+
+    assert sanitized["connectors"][0]["auth"]["access_token"] == REDACTION
+    assert sanitized["connectors"][0]["auth"]["client_secret"] == REDACTION
+
+
 def test_sanitize_export_does_not_mutate_top_level_payload():
     payload = {"tenant_id": "atlas", "api_key": "sk-live-123"}
 


### PR DESCRIPTION
This carries the sanitizer through nested connector/auth structures so support/admin export summaries do not expose connector credentials.

Notes from the prototype pass:
- Redacts nested `access_token` and `client_secret` under connector auth blocks.
- Preserves the existing non-mutating copy behavior for the examples covered here.
- Still uses broad fragment matching, so fields like `secretary_email` and `public_token_hint` need a closer read before this is safe to merge.

I’m leaving this open because it may be useful history, not necessarily the final shape.