### PR TITLE
Tighten admin export secret key matching

### DIFF
--- a/src/tc1_export_sanitizer.py
+++ b/src/tc1_export_sanitizer.py
@@ -1,7 +1,15 @@
 """Helpers for preparing TC1 admin export bundles."""
 
 REDACTION = "[redacted]"
-SENSITIVE_FRAGMENTS = {"password", "token", "secret", "api_key", "private_key"}
+SENSITIVE_KEYS = {
+    "api_key",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "signing_secret",
+    "password",
+    "private_key",
+}
 
 
 def _normalize_key(key):
@@ -9,17 +17,11 @@ def _normalize_key(key):
 
 
 def _is_sensitive_key(key):
-    normalized = _normalize_key(key)
-    return any(fragment in normalized for fragment in SENSITIVE_FRAGMENTS)
+    return _normalize_key(key) in SENSITIVE_KEYS
 
 
 def sanitize_export(payload):
-    """Return a sanitized top-level copy of an admin export payload.
-
-    The sanitizer is used for support/admin bundle previews before data leaves TC1.
-    It intentionally avoids changing the source payload object because preview and
-    audit views may be rendered from the same parsed export.
-    """
+    """Return a sanitized top-level copy of an admin export payload."""
     if not isinstance(payload, dict):
         return payload
 

--- a/tests/test_tc1_export_sanitizer.py
+++ b/tests/test_tc1_export_sanitizer.py
@@ -17,6 +17,19 @@ def test_sanitize_export_redacts_top_level_secrets():
     assert sanitized["workspace_id"] == "ws-1"
 
 
+def test_sanitize_export_preserves_safe_secret_like_labels():
+    payload = {
+        "tenant_id": "atlas",
+        "secretary_email": "ops@example.test",
+        "public_token_hint": "starts-with-xoxb",
+    }
+
+    sanitized = sanitize_export(payload)
+
+    assert sanitized["secretary_email"] == "ops@example.test"
+    assert sanitized["public_token_hint"] == "starts-with-xoxb"
+
+
 def test_sanitize_export_does_not_mutate_top_level_payload():
     payload = {"tenant_id": "atlas", "api_key": "sk-live-123"}
 


### PR DESCRIPTION
This narrows the admin export sanitizer from broad fragment matching to exact normalized secret keys.

Why this exists:
- Avoids hiding safe fields such as `secretary_email` and `public_token_hint`.
- Keeps the current non-mutating sanitizer behavior.
- Does not yet prove nested connector auth is redacted, so this may only be a partial fix for the current report.

Leaving as open implementation history until the active TC1 work is reconciled.