### PR TITLE
Fix admin export sanitizer recursion

### DIFF
--- a/src/tc1_export_sanitizer.py
+++ b/src/tc1_export_sanitizer.py
@@ -1,7 +1,15 @@
 """Helpers for preparing TC1 admin export bundles."""
 
 REDACTION = "[redacted]"
-SENSITIVE_FRAGMENTS = {"password", "token", "secret", "api_key", "private_key"}
+SENSITIVE_KEYS = {
+    "api_key",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "signing_secret",
+    "password",
+    "private_key",
+}
 
 
 def _normalize_key(key):
@@ -9,25 +17,28 @@ def _normalize_key(key):
 
 
 def _is_sensitive_key(key):
-    normalized = _normalize_key(key)
-    return any(fragment in normalized for fragment in SENSITIVE_FRAGMENTS)
+    return _normalize_key(key) in SENSITIVE_KEYS
+
+
+def _sanitize_value(value):
+    if isinstance(value, dict):
+        return {
+            key: REDACTION if _is_sensitive_key(key) else _sanitize_value(child)
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize_value(item) for item in value]
+    return value
 
 
 def sanitize_export(payload):
-    """Return a sanitized top-level copy of an admin export payload.
+    """Return a sanitized copy of an admin export payload.
 
     The sanitizer is used for support/admin bundle previews before data leaves TC1.
     It intentionally avoids changing the source payload object because preview and
     audit views may be rendered from the same parsed export.
     """
-    if not isinstance(payload, dict):
-        return payload
-
-    sanitized = dict(payload)
-    for key in list(sanitized):
-        if _is_sensitive_key(key):
-            sanitized[key] = REDACTION
-    return sanitized
+    return _sanitize_value(payload)
 
 
 def summarize_export(payload):

--- a/tests/test_tc1_export_sanitizer.py
+++ b/tests/test_tc1_export_sanitizer.py
@@ -17,6 +17,52 @@ def test_sanitize_export_redacts_top_level_secrets():
     assert sanitized["workspace_id"] == "ws-1"
 
 
+def test_sanitize_export_redacts_nested_connector_auth():
+    payload = {
+        "tenant_id": "atlas",
+        "connectors": [
+            {
+                "name": "slack",
+                "auth": {
+                    "access_token": "xoxb-live",
+                    "client_secret": "shh",
+                },
+            },
+            {
+                "name": "github",
+                "auth": {
+                    "refresh-token": "gho-live",
+                    "signing secret": "signed",
+                },
+            },
+        ],
+    }
+
+    sanitized = sanitize_export(payload)
+
+    assert sanitized["connectors"][0]["auth"]["access_token"] == REDACTION
+    assert sanitized["connectors"][0]["auth"]["client_secret"] == REDACTION
+    assert sanitized["connectors"][1]["auth"]["refresh-token"] == REDACTION
+    assert sanitized["connectors"][1]["auth"]["signing secret"] == REDACTION
+    assert sanitized["connectors"][0]["name"] == "slack"
+    assert sanitized["connectors"][1]["name"] == "github"
+
+
+def test_sanitize_export_preserves_safe_secret_like_labels():
+    payload = {
+        "tenant_id": "atlas",
+        "owner_email": "ops@example.test",
+        "secretary_email": "release-coord@example.test",
+        "public_token_hint": "xoxb-****",
+    }
+
+    sanitized = sanitize_export(payload)
+
+    assert sanitized["owner_email"] == "ops@example.test"
+    assert sanitized["secretary_email"] == "release-coord@example.test"
+    assert sanitized["public_token_hint"] == "xoxb-****"
+
+
 def test_sanitize_export_does_not_mutate_top_level_payload():
     payload = {"tenant_id": "atlas", "api_key": "sk-live-123"}
 
@@ -24,6 +70,30 @@ def test_sanitize_export_does_not_mutate_top_level_payload():
 
     assert sanitized is not payload
     assert payload["api_key"] == "sk-live-123"
+
+
+def test_sanitize_export_does_not_mutate_nested_payload():
+    payload = {
+        "tenant_id": "atlas",
+        "connectors": [
+            {
+                "name": "slack",
+                "auth": {
+                    "access_token": "xoxb-live",
+                    "client_secret": "shh",
+                },
+            }
+        ],
+    }
+
+    sanitized = sanitize_export(payload)
+
+    assert sanitized is not payload
+    assert sanitized["connectors"] is not payload["connectors"]
+    assert sanitized["connectors"][0] is not payload["connectors"][0]
+    assert sanitized["connectors"][0]["auth"] is not payload["connectors"][0]["auth"]
+    assert payload["connectors"][0]["auth"]["access_token"] == "xoxb-live"
+    assert payload["connectors"][0]["auth"]["client_secret"] == "shh"
 
 
 def test_summarize_export_counts_connectors_and_includes_sanitized_copy():


### PR DESCRIPTION
## Summary

Fixes the admin/support export sanitizer so support summaries redact exact secret keys at any depth without hiding safe labels and without mutating the source parsed payload used by audit preview.

## Root Cause

The current sanitizer only made a shallow top-level copy and used broad fragment matching. That left nested connector auth values visible in support summaries, while prototype branches that reached nested data either hid safe fields like `secretary_email` / `public_token_hint` or mutated the shared payload object.

## Changes

- Replace broad fragment matching with exact normalized secret-key matching.
- Recursively sanitize dictionaries and lists while returning copied containers.
- Preserve safe identity/contact fields and public hints.
- Add regressions for nested connector auth redaction, safe-label preservation, and nested non-mutation.

## Validation

- `PYTHONPYCACHEPREFIX=/Users/fernandomano/Documents/Codex/2026-08-12/goal-resolve-a-meaningful-current-tc1/work/pycache /private/tmp/TC1-fresh-py312-venv/bin/python -m pytest tests/test_tc1_export_sanitizer.py` — 6 passed
- `PYTHONPYCACHEPREFIX=/Users/fernandomano/Documents/Codex/2026-08-12/goal-resolve-a-meaningful-current-tc1/work/pycache /private/tmp/TC1-fresh-py312-venv/bin/python -m pytest` — 231 passed
- `PYTHONPYCACHEPREFIX=/Users/fernandomano/Documents/Codex/2026-08-12/goal-resolve-a-meaningful-current-tc1/work/pycache /private/tmp/TC1-fresh-py312-venv/bin/python -m compileall -q src/tc1_export_sanitizer.py tests/test_tc1_export_sanitizer.py`
- `git diff --check`

Closes #530.
Refs #531, #532, #533.