### PR TITLE
Closed: dashboard pauseSeconds covered by full drain recovery

### DIFF
--- a/src/tc1_pause_window.py
+++ b/src/tc1_pause_window.py
@@ -35,7 +35,7 @@ def _scope_key(tenant_id, route_id):
 def build_pause_window(record, workspace_default_seconds=DEFAULT_PAUSE_SECONDS):
     """Return the route-scoped pause window used by retry and drain workers."""
     tenant_id = str(record.get("tenant_id") or "")
-    hold_seconds = _coerce_seconds(record.get("hold_seconds"))
+    hold_seconds = _coerce_seconds(record.get("hold_seconds") or record.get("pauseSeconds"))
     if hold_seconds is None:
         hold_seconds = int(workspace_default_seconds)
 

--- a/tests/test_tc1_pause_window.py
+++ b/tests/test_tc1_pause_window.py
@@ -42,3 +42,12 @@ def test_pause_window_accepts_legacy_route_before_destination_fallback():
 
     assert window["route_id"] == "legacy-bank"
     assert window["scope_key"] == "atlas:legacy-bank"
+
+
+def test_pause_window_reads_dashboard_pause_seconds_string():
+    window = build_pause_window(
+        {"tenant_id": "atlas", "route_id": "bank", "pauseSeconds": "0"},
+        workspace_default_seconds=180,
+    )
+
+    assert window["hold_seconds"] == 0


### PR DESCRIPTION
Superseded by PR #535.

This branch only covered the dashboard `pauseSeconds` string path. The merged recovery in #535 covers dashboard `pauseSeconds` plus persisted drain `pause_seconds`, preserves route-scoped output and route identity order, and keeps blank/missing duration values inheriting workspace defaults.

Merged replacement: https://github.com/fermano/TC1/pull/535
Merge commit on `main`: `33a275943e81bcdc6ef649abbf31e5c4e52e1603`.