### PR TITLE
Exclude disabled workspaces from retry digest queue

### DIFF
--- a/src/tc1_digest_disabled_workspace.py
+++ b/src/tc1_digest_disabled_workspace.py
@@ -1,0 +1,9 @@
+"""Retry digest filters for disabled TC1 workspaces."""
+
+
+def digest_queue_candidate(workspace):
+    if workspace.get("deleted_at"):
+        return False
+    if workspace.get("disabled"):
+        return False
+    return bool(workspace.get("retry_enabled", True))


### PR DESCRIPTION
Prevents disabled or deleted workspaces from entering the retry digest queue.

Known gap: the branch has no test for the disabled-but-retry-enabled workspace from the release-room note. The author mentioned local validation in Slack, but no repository evidence is attached here.