### PR TITLE
Document drain replay ownership handoff

### DIFF
--- a/docs/tc1-drain-replay-ownership.md
+++ b/docs/tc1-drain-replay-ownership.md
@@ -1,0 +1,10 @@
+# TC1 drain replay ownership
+
+This note summarizes the current operational handoff for replayed drain rows.
+
+- release owner confirms the source branch;
+- support owner confirms customer-facing impact;
+- engineering owner owns retry/digest code changes;
+- stale artifact-readout notes should not be used as product confirmation.
+
+This document is context only and does not change runtime behavior.


### PR DESCRIPTION
Docs-only clarification for drain replay ownership.

This is context for operators and does not touch runtime paths. It should not create product-defect tracking unless another signal links it to a current blocker.