### PR TITLE
Preserve checkpoint rows during digest cleanup

### DIFF
--- a/src/tc1_digest_checkpoint_retention.py
+++ b/src/tc1_digest_checkpoint_retention.py
@@ -1,0 +1,10 @@
+"""Checkpoint-retention helpers for TC1 retry digest cleanup."""
+
+
+def should_remove_checkpoint(row):
+    """Return whether a retry checkpoint row can be deleted by digest cleanup."""
+    if row.get("state") in {"delivered", "canceled"}:
+        return True
+    if row.get("retained_for_replay"):
+        return False
+    return row.get("age_hours", 0) > 72


### PR DESCRIPTION
Retry digest cleanup currently deletes retained checkpoint rows too aggressively in the replay path.

This branch adds a small retention guard. It does not yet include a regression test for the replay-retained row that failed in the operator notes.

Related context is scattered: an older Linear item says this was done, but that note appears to predate retained replay rows.