### PR TITLE
Normalize hold reason labels for operator view

### DIFF
--- a/src/tc1_hold_reason_labels.py
+++ b/src/tc1_hold_reason_labels.py
@@ -1,0 +1,13 @@
+"""Operator-facing hold reason normalization."""
+
+_REASON_LABELS = {
+    "customer_paused": "Customer paused",
+    "customer-paused": "Customer paused",
+    "manual_hold": "Manual hold",
+    "manual-hold": "Manual hold",
+}
+
+
+def operator_hold_reason(value):
+    normalized = str(value or "").strip().lower()
+    return _REASON_LABELS.get(normalized, normalized.replace("_", " ").title())


### PR DESCRIPTION
Normalizes operator-facing hold reason labels so `customer-paused` and `customer_paused` render consistently.

Potential overlap: PRs and issues around digest/escalation reason values may be related, but this branch is focused on operator display labels.