### PR TITLE
Normalize escalation reason before digest fanout

### DIFF
--- a/src/tc1_escalation_reason_digest.py
+++ b/src/tc1_escalation_reason_digest.py
@@ -1,0 +1,10 @@
+"""Digest-facing escalation reason normalization."""
+
+
+def digest_reason(value):
+    text = str(value or "").strip().lower().replace("-", "_")
+    if text == "customer_paused":
+        return "customer_paused"
+    if text == "manual_hold":
+        return "manual_hold"
+    return text


### PR DESCRIPTION
Normalizes escalation reason values before retry digest fanout.

This may overlap with the operator label PR, but the fanout value is machine-facing while the operator label is display-facing. Needs triage to avoid duplicate work or accidental divergence.