### PR TITLE
Backfill legacy token on export replay

### DIFF
--- a/src/tc1_legacy_export_token.py
+++ b/src/tc1_legacy_export_token.py
@@ -1,0 +1,9 @@
+"""Legacy export replay token normalization."""
+
+
+def export_token(record):
+    if record.get("export_token"):
+        return record["export_token"]
+    if record.get("legacy_token"):
+        return record["legacy_token"]
+    return None


### PR DESCRIPTION
Uses `legacy_token` when replay records do not yet contain `export_token`.

The branch has no tests for the EU dry-run sample mentioned in the issue thread. There is an old canceled Linear issue with a similar title; it may or may not be the correct tracker.