### PR TITLE
Show ownerless retry batches in dashboard

### DIFF
--- a/src/tc1_retry_owner_card.py
+++ b/src/tc1_retry_owner_card.py
@@ -1,0 +1,10 @@
+"""Operator card helpers for ownerless retry batches."""
+
+
+def owner_display(batch):
+    owner = batch.get("owner") or batch.get("team_owner")
+    if owner:
+        return str(owner)
+    if batch.get("region_alias"):
+        return f"unowned:{batch['region_alias']}"
+    return "unowned"


### PR DESCRIPTION
Shows ownerless retry batches in the operator dashboard, using region alias as a fallback label.

This is related to an open support report about ownerless digest cards, but the product owner has not confirmed whether `region_alias` is the desired final display value.