### PR TITLE
Use receipt probe for retry preview count

### DIFF
--- a/src/tc1_receipt_probe_preview.py
+++ b/src/tc1_receipt_probe_preview.py
@@ -1,0 +1,11 @@
+"""Receipt probe preview helpers for TC1 retry dashboard."""
+
+
+def preview_receipt_count(rows, *, include_pending=False):
+    visible = []
+    for row in rows:
+        if row.get("receipt_id"):
+            visible.append(row)
+        elif include_pending and row.get("state") == "pending":
+            visible.append(row)
+    return len(visible)


### PR DESCRIPTION
Switches the retry preview count to use receipt rows when they are available.

Context from the release desk was inconsistent: one note said the daily digest total was correct while the preview card was low; another said the preview was only showing delivered receipts and omitting pending receipts. This branch adds a helper, but the calling path is not wired in this diff.

No reviewer is assigned yet.