### PR TITLE
Add retry card glossary examples

### DIFF
--- a/docs/tc1-retry-card-glossary.md
+++ b/docs/tc1-retry-card-glossary.md
@@ -1,0 +1,7 @@
+# Retry card glossary
+
+- Owner: person or team expected to handle a retry batch.
+- Region alias: short operator-facing alias used when the owner is not yet known.
+- Receipt probe: preview-only count from receipt rows used before the daily digest is finalized.
+
+The examples are illustrative and not an API contract.


### PR DESCRIPTION
Adds operator glossary examples for retry cards, owner labels, region aliases, and receipt probe counts.

The glossary includes examples copied from recent screenshots, but does not change runtime behavior.