### PR TITLE
Simplify disabled workspace replay selection

### DIFF
--- a/src/tc1_digest_replay_selector.py
+++ b/src/tc1_digest_replay_selector.py
@@ -1,0 +1,7 @@
+"""Replay candidate selector used by digest backfill."""
+
+
+def replay_candidate(workspace):
+    if workspace.get("deleted_at"):
+        return False
+    return bool(workspace.get("retry_enabled", True))


### PR DESCRIPTION
Simplifies replay candidate selection for digest backfill.

The branch keeps deleted workspaces out, but does not check the `disabled` flag. The author note says disabled accounts should already be filtered before replay selection. The daily digest queue and replay backfill may not use the same entry point.