### PR TITLE
Handle partner paused hold reason

### DIFF
--- a/src/tc1_partner_hold_reason.py
+++ b/src/tc1_partner_hold_reason.py
@@ -1,0 +1,12 @@
+"""Partner hold reason helpers."""
+
+_REASON_ALIASES = {
+    "partner-paused": "partner_paused",
+    "partner_paused": "partner_paused",
+    "customer-paused": "customer_paused",
+    "customer_paused": "customer_paused",
+}
+
+
+def partner_hold_reason(value):
+    return _REASON_ALIASES.get(str(value or "").strip().lower(), "unknown")


### PR DESCRIPTION
Adds alias handling for `partner-paused` and `partner_paused` in a partner hold helper.

This is similar to the older customer-paused work, but the partner case came from a later digest CSV sample. Operator labels were not mentioned in that sample.