### PR TITLE
Require explicit export token on replay rows

### DIFF
--- a/src/tc1_export_token_strict.py
+++ b/src/tc1_export_token_strict.py
@@ -1,0 +1,8 @@
+"""Strict export token helper for replay rows."""
+
+
+def replay_export_token(record):
+    token = record.get("export_token")
+    if token:
+        return token
+    return ""


### PR DESCRIPTION
Moves replay rows toward explicit `export_token` usage and returns an empty token when it is absent.

The motivation was to stop treating old staging fixtures as canonical. The EU dry-run sample from earlier this week is not mentioned in the code comment or tests.