### PR TITLE
Preserve cents in Meridian export preview

### DIFF
--- a/src/tc1_meridian_export_preview.py
+++ b/src/tc1_meridian_export_preview.py
@@ -1,0 +1,15 @@
+"""Meridian export preview helpers for TC1 release triage."""
+
+
+def preview_amount_cents(row):
+    amount = row.get("amount_cents")
+    if amount is None:
+        return int(float(row.get("amount", 0)) * 100)
+    return int(amount)
+
+
+def preview_tax_cents(row):
+    tax = row.get("tax_cents")
+    if tax is None:
+        return int(float(row.get("tax", 0)) * 100)
+    return int(tax)


### PR DESCRIPTION
Adds a small helper for preview amount/tax cents in the Meridian export path.

Related release note: RC-73 readout showed `preview_vat=19` while the CSV retained `19.37`. This branch covers cents helpers but does not show where the preview renderer calls them yet.

No Linear link was included in the release note.