### PR TITLE
Closed: superseded by route-scoped RC74 zero dispatch fix

### DIFF
--- a/src/tc1_lagoon_dispatch_delay.py
+++ b/src/tc1_lagoon_dispatch_delay.py
@@ -1,0 +1,21 @@
+"""Lagoon dispatch delay override prototype.
+
+This prototype came from the original Lagoon customer incident. It preserves an
+explicit zero-delay override, but it uses the old tenant-level output shape.
+"""
+
+
+def dispatch_delay_seconds(record, workspace_default=300):
+    if "delay_seconds" in record and record.get("delay_seconds") not in (None, ""):
+        return int(record["delay_seconds"])
+    if "send_after_seconds" in record and record.get("send_after_seconds") not in (None, ""):
+        return int(record["send_after_seconds"])
+    return int(workspace_default)
+
+
+def lagoon_dispatch_record(record, workspace_default=300):
+    return {
+        "tenant_id": record.get("tenant_id"),
+        "delay_seconds": dispatch_delay_seconds(record, workspace_default),
+        "source": "lagoon-flat-prototype",
+    }


### PR DESCRIPTION
Prototype from the Lagoon incident.

It keeps explicit `delay_seconds=0` / `send_after_seconds=0` as a real immediate-dispatch override instead of falling back to the workspace default.

This was written before RC-74 moved dispatch records to route-scoped `scope_key` output, so the branch still returns a tenant-level shape. The Lagoon note did not mention route IDs when this was opened.