### PR TITLE
Closed: route-scope tests included in RC74 zero dispatch fix

### DIFF
--- a/tests/test_tc1_lagoon_release_window.py
+++ b/tests/test_tc1_lagoon_release_window.py
@@ -1,0 +1,15 @@
+from src.tc1_lagoon_release_window import release_dispatch_record
+
+
+def test_release_window_uses_route_scope():
+    row = {"tenant_id": "lagoon", "route_id": "sms", "route_window_seconds": 90}
+    assert release_dispatch_record(row) == {
+        "scope_key": "lagoon:sms",
+        "window_seconds": 90,
+        "source": "rc74-route-scoped",
+    }
+
+
+def test_release_window_falls_back_to_default_when_blank():
+    row = {"tenant_id": "lagoon", "route_id": "email", "window_seconds": ""}
+    assert release_dispatch_record(row, workspace_default=240)["window_seconds"] == 240


### PR DESCRIPTION
Adds tests around the RC-74 route-scoped dispatch window helper.

This is based on the current release branch shape: `scope_key`, route identity order, and `window_seconds`. It covers route scoping and blank fallback, but it does not cover Lagoon's explicit zero-delay override from the earlier incident thread.