### PR TITLE
Document RC74 dispatch window dashboard copy

### DIFF
--- a/docs/tc1-rc74-dispatch-window-copy.md
+++ b/docs/tc1-rc74-dispatch-window-copy.md
@@ -1,0 +1,10 @@
+# RC-74 dispatch window copy
+
+Operator dashboard labels use "dispatch window" for route-scoped release rows.
+
+Examples:
+
+- `lagoon:sms` → Dispatch window: 90 seconds
+- `lagoon:email` → Dispatch window: workspace default
+
+This note is display-copy context only.


### PR DESCRIPTION
Adds operator-dashboard wording for RC-74 dispatch windows.

This is docs/display-copy context only. It does not change dispatch behavior or release artifact rows.