### PR TITLE
Preserve RC74 Lagoon zero dispatch window

### DIFF
--- a/src/tc1_lagoon_release_window.py
+++ b/src/tc1_lagoon_release_window.py
@@ -11,10 +11,9 @@ def route_key(record):
 
 
 def dispatch_window_seconds(record, workspace_default=300):
-    if "window_seconds" in record and record.get("window_seconds") not in (None, ""):
-        return int(record["window_seconds"])
-    if "route_window_seconds" in record and record.get("route_window_seconds") not in (None, ""):
-        return int(record["route_window_seconds"])
+    for field in ("window_seconds", "route_window_seconds", "send_after_seconds", "delay_seconds"):
+        if field in record and record.get(field) not in (None, ""):
+            return int(record[field])
     return int(workspace_default)
 
 

--- a/tests/test_tc1_lagoon_release_window.py
+++ b/tests/test_tc1_lagoon_release_window.py
@@ -1,0 +1,33 @@
+from src.tc1_lagoon_release_window import release_dispatch_record
+
+
+def test_release_window_uses_route_scope():
+    row = {"tenant_id": "lagoon", "route_id": "sms", "route_window_seconds": 90}
+
+    assert release_dispatch_record(row) == {
+        "scope_key": "lagoon:sms",
+        "window_seconds": 90,
+        "source": "rc74-route-scoped",
+    }
+
+
+def test_release_window_falls_back_to_default_when_blank():
+    row = {"tenant_id": "lagoon", "route_id": "email", "window_seconds": ""}
+
+    assert release_dispatch_record(row, workspace_default=240)["window_seconds"] == 240
+
+
+def test_release_window_preserves_lagoon_sms_immediate_override():
+    row = {"tenant_id": "lagoon", "route_id": "sms", "send_after_seconds": 0}
+
+    assert release_dispatch_record(row) == {
+        "scope_key": "lagoon:sms",
+        "window_seconds": 0,
+        "source": "rc74-route-scoped",
+    }
+
+
+def test_release_window_reads_flat_prototype_delay_alias():
+    row = {"tenant_id": "lagoon", "route_id": "sms", "delay_seconds": "0"}
+
+    assert release_dispatch_record(row, workspace_default=300)["window_seconds"] == 0


### PR DESCRIPTION
## Summary

Closes #575.

Fixes the RC-74 Lagoon dispatch-window helper so explicit zero dispatch values are preserved inside the current route-scoped artifact shape.

## What changed

- Keeps `scope_key` / `window_seconds` output for RC-74 release rows.
- Preserves the existing `window_seconds` and `route_window_seconds` priority.
- Accepts `send_after_seconds` and `delay_seconds` as non-blank dispatch window aliases after the current release fields.
- Adds regression coverage for route scope, blank default inheritance, Lagoon SMS `send_after_seconds=0`, and the flat prototype `delay_seconds="0"` alias.

## Reconciled history

- PR #572 had the right explicit-zero behavior, but it targeted `main` and returned stale tenant-level `tenant_id` / `delay_seconds` rows.
- PR #573 matched the current `release/rc-74` route-scoped shape, but it only tested route scope and blank fallback.
- PR #574 is dashboard copy context only and does not change release artifact behavior.

## Validation

- `PYTHONPYCACHEPREFIX=/Users/fernandomano/Documents/Codex/2026-08-13/use-this-for-1-goal-resolve-2/work/pycache /private/tmp/TC1-venv/bin/python -m pytest tests/test_tc1_lagoon_release_window.py -q` -> 4 passed.
- `PYTHONPYCACHEPREFIX=/Users/fernandomano/Documents/Codex/2026-08-13/use-this-for-1-goal-resolve-2/work/pycache /private/tmp/TC1-venv/bin/python scripts/verify_repo_baseline.py` -> passed.
- `PYTHONPYCACHEPREFIX=/Users/fernandomano/Documents/Codex/2026-08-13/use-this-for-1-goal-resolve-2/work/pycache /private/tmp/TC1-venv/bin/python -m compileall -q src/tc1_lagoon_release_window.py tests/test_tc1_lagoon_release_window.py` -> passed.
- `git diff --check` -> passed.

The local full-suite attempt under macOS Python 3.9 failed at collection because the repository uses Python 3.10+ union type syntax. The repository CI workflow runs pull requests on Python 3.12, so CI is the full-suite validation source for this PR.