### PR TITLE
Recover RC75 Harbor invoice gate zero override

### DIFF
--- a/src/tc1_harbor_invoice_gate.py
+++ b/src/tc1_harbor_invoice_gate.py
@@ -13,10 +13,9 @@ def lane_key(record):
 
 
 def gate_seconds(record, default_seconds=45):
-    if record.get("gate_seconds") not in (None, ""):
-        return int(record["gate_seconds"])
-    if record.get("route_gate_seconds") not in (None, ""):
-        return int(record["route_gate_seconds"])
+    for field in ("gate_seconds", "route_gate_seconds", "cancel_after_seconds", "gate_delay_seconds"):
+        if record.get(field) not in (None, ""):
+            return int(record[field])
     return int(default_seconds)
 
 

--- a/tests/test_tc1_harbor_invoice_gate.py
+++ b/tests/test_tc1_harbor_invoice_gate.py
@@ -1,0 +1,19 @@
+from src.tc1_harbor_invoice_gate import invoice_gate_record
+
+
+def test_invoice_gate_uses_lane_key_for_bank_route():
+    row = {"tenant_id": "harbor", "route_id": "bank", "invoice_id": "inv-992", "route_gate_seconds": 90}
+    assert invoice_gate_record(row) == {
+        "lane_key": "harbor:bank:inv-992",
+        "gate_seconds": 90,
+        "source": "rc75-lane-scoped",
+    }
+
+
+def test_invoice_gate_blank_value_uses_default_for_email_route():
+    row = {"tenant_id": "harbor", "route_id": "email", "invoice_id": "inv-992", "gate_seconds": ""}
+    assert invoice_gate_record(row, default_seconds=45) == {
+        "lane_key": "harbor:email:inv-992",
+        "gate_seconds": 45,
+        "source": "rc75-lane-scoped",
+    }

--- a/tests/test_tc1_harbor_invoice_gate.py
+++ b/tests/test_tc1_harbor_invoice_gate.py
@@ -17,3 +17,27 @@ def test_invoice_gate_blank_value_uses_default_for_email_route():
         "gate_seconds": 45,
         "source": "rc75-lane-scoped",
     }
+
+
+def test_invoice_gate_preserves_explicit_zero_for_bank_route():
+    row = {
+        "tenant_id": "harbor",
+        "route_id": "bank",
+        "invoice_id": "inv-992",
+        "cancel_after_seconds": 0,
+    }
+    assert invoice_gate_record(row, default_seconds=45) == {
+        "lane_key": "harbor:bank:inv-992",
+        "gate_seconds": 0,
+        "source": "rc75-lane-scoped",
+    }
+
+
+def test_invoice_gate_preserves_string_zero_legacy_gate_delay():
+    row = {
+        "tenant_id": "harbor",
+        "route_id": "bank",
+        "invoice_id": "inv-992",
+        "gate_delay_seconds": "0",
+    }
+    assert invoice_gate_record(row, default_seconds=45)["gate_seconds"] == 0


### PR DESCRIPTION
Selected RC-75 recovery PR for Harbor invoice gate rows.

This branch targets `release/rc-75` and preserves the current RC-75 lane-scoped output shape: `lane_key`, `gate_seconds`, and separate bank/email routes for the same invoice.

What changed:
- `gate_seconds()` now treats explicit `cancel_after_seconds` and legacy `gate_delay_seconds` values as real gate inputs, including numeric/string zero.
- Missing or blank values still inherit the workspace default.
- Harbor bank and email rows remain separate through the lane key.

History reconciled:
- PR #581 had the still-valid explicit-zero behavior, but it targets `main` and emits stale tenant/invoice-shaped output.
- PR #582 is dashboard/display context only and is not the artifact unblock.

Validation:
- Local: `/private/tmp/TC1-venv/bin/python -m pytest tests/test_tc1_harbor_invoice_gate.py -q` -> 4 passed.
- Local: `python3 scripts/verify_repo_baseline.py` -> `TC1 repository baseline looks ready.`
- Local: `PYTHONPYCACHEPREFIX=/private/tmp/TC1-pycache /private/tmp/TC1-venv/bin/python -m compileall src tests/test_tc1_harbor_invoice_gate.py -q` -> passed.
- Local: `git diff --check` -> passed.
- Local full-suite attempt under Python 3.9 failed during collection on Python 3.10+ type-union syntax; CI uses Python 3.12.
- GitHub Actions CI run #604 on head `336ba4a03500ce703e62e6ba177a35825801a6f5` passed `unit-tests` with `python -m pytest`.