### PR TITLE
Document RC75 Harbor gate dashboard rows

### DIFF
--- a/docs/tc1-rc75-harbor-gate-dashboard.md
+++ b/docs/tc1-rc75-harbor-gate-dashboard.md
@@ -1,0 +1,11 @@
+# RC-75 Harbor invoice gate dashboard
+
+The dashboard should display lane-scoped invoice gate rows for Harbor.
+
+Examples:
+
+- `harbor:bank:inv-992` → Gate: immediate
+- `harbor:email:inv-992` → Gate: workspace default
+- `harbor:card:inv-992` → Gate: route value
+
+This document is operator-display context. It is not an artifact recovery.


### PR DESCRIPTION
Adds dashboard/operator copy for Harbor RC-75 invoice gate rows.

This reflects the expected labels for immediate, default, and route-specific gates. It does not change the release artifact helper or generated row behavior.