### PR TITLE
Document RC76 Slate credit memo dashboard labels

### DIFF
--- a/docs/tc1-rc76-slate-credit-dashboard.md
+++ b/docs/tc1-rc76-slate-credit-dashboard.md
@@ -1,0 +1,9 @@
+# RC-76 Slate credit memo dashboard rows
+
+Operator copy should display these rows as one of:
+
+- `Credit memo applied`
+- `No credit memo`
+- `Legacy invoice row`
+
+This page documents display text only. It does not change the RC-76 artifact helper or the exported row action.


### PR DESCRIPTION
Adds dashboard/operator copy for RC-76 Slate credit memo rows.

This reflects display labels for credit memo, no-credit, and legacy invoice rows. It does not change the release artifact helper or exported row action.