### PR TITLE
Preserve Slate zero-credit memo action

### DIFF
--- a/src/tc1_rc76_slate_zero_credit_legacy.py
+++ b/src/tc1_rc76_slate_zero_credit_legacy.py
@@ -1,0 +1,21 @@
+"""Legacy Slate zero-credit memo prototype.
+
+This came from the customer handoff before RC-76 moved the artifact to
+outlet-scoped rows. The zero-cent behavior is valid, but the row shape is not.
+"""
+
+
+def legacy_credit_action(record):
+    memo_id = record.get("credit_memo_id") or record.get("legacy_credit_memo_id")
+    if memo_id not in (None, ""):
+        return "credit_memo"
+    return "none"
+
+
+def legacy_credit_row(record):
+    return {
+        "tenant_id": record.get("tenant_id") or "unknown",
+        "invoice_id": record.get("invoice_id") or record.get("legacy_invoice_id") or "unassigned",
+        "credit_cents": int(record.get("credit_cents") or 0),
+        "action": legacy_credit_action(record),
+    }


### PR DESCRIPTION
Older Slate prototype from the customer handoff.

It preserves the still-valid behavior that a present `credit_memo_id` means `action=credit_memo` even when `credit_cents=0`.

This branch targets `main` and emits the old tenant/invoice row shape rather than the RC-76 outlet-scoped release shape, so it should be treated as implementation history rather than merged directly into the release branch.