### PR TITLE
Prototype transfer window alias normalization

### DIFF
--- a/src/tc1_rc81_transfer.py
+++ b/src/tc1_rc81_transfer.py
@@ -1,0 +1,24 @@
+"""Prototype transfer window normalizer from before RC81 route rows."""
+
+DEFAULT_HOLD_SECONDS = 300
+
+
+def _hold_seconds(payload, default=DEFAULT_HOLD_SECONDS):
+    if "hold_seconds" in payload and payload["hold_seconds"] not in (None, ""):
+        return int(payload["hold_seconds"])
+    if "holdSeconds" in payload and payload["holdSeconds"] not in (None, ""):
+        return int(payload["holdSeconds"])
+    return default
+
+
+def build_transfer_row(payload, defaults=None):
+    defaults = {"hold_seconds": DEFAULT_HOLD_SECONDS, **(defaults or {})}
+    hold_seconds = _hold_seconds(payload, defaults["hold_seconds"])
+    return {
+        "tenant_id": payload["tenant_id"],
+        "destination_id": payload.get("destination_id") or payload.get("route_id") or "primary",
+        "transfer_id": payload["transfer_id"],
+        "hold_seconds": hold_seconds,
+        "action": "hold" if hold_seconds > 0 else "release",
+        "source": "mainline-window-normalizer",
+    }

--- a/tests/test_tc1_rc81_transfer.py
+++ b/tests/test_tc1_rc81_transfer.py
@@ -1,0 +1,12 @@
+from src.tc1_rc81_transfer import build_transfer_row
+
+
+def test_camel_case_zero_hold_seconds_is_explicit():
+    row = build_transfer_row({
+        "tenant_id": "kitebank",
+        "destination_id": "ach",
+        "transfer_id": "tr-884",
+        "holdSeconds": "0",
+    })
+    assert row["hold_seconds"] == 0
+    assert row["action"] == "release"


### PR DESCRIPTION
Related to #595.

Adds alias handling for `holdSeconds` and preserves explicit zero, but this was written against the older destination-shaped output. Do not assume it can be merged directly to the RC81 release branch without reconciling the route row shape.

## Final reconciliation — 2026-08-31

Closed unmerged as superseded by [PR #596](https://github.com/fermano/TC1/pull/596), merged into `release/rc-81` as `9ac4671`. Its useful alias precedence and numeric/string-zero semantics are now covered on the current release row shape, including the `d6ee355` schema/operator fields. The old destination-shaped output and `mainline-window-normalizer` marker are not valid RC81 output and were not copied. No mainline rollout is claimed. See #595 for validation and completion evidence.