### PR TITLE
RC81 KiteBank readout notes

### DIFF
--- a/docs/rc81_kite_readout_2026_08_31.md
+++ b/docs/rc81_kite_readout_2026_08_31.md
@@ -1,0 +1,5 @@
+# KiteBank RC81 readout note
+
+The 18:20 BRT dashboard smoke shows the transfer-row count matching yesterday's candidate. That check does not inspect `holdSeconds` on the partner artifact row.
+
+Ambiguous status: support marked the card green because the total row count recovered, while release notes still say the `kitebank/ach/tr-884` action should not be considered verified until the artifact row is inspected.


### PR DESCRIPTION
Refs #594 and mentions #595.

Documents that the count smoke is green but shallow. This PR does not change artifact behavior.

## Final reconciliation — 2026-08-31

Closed unmerged as superseded readout context. Merged recovery [PR #596](https://github.com/fermano/TC1/pull/596) updates `docs/rc81_transfer_handoff.md` with the count-smoke limitation and verified row contract, alongside the implementation and tests. The historical count-green signal did not clear #595; repository-visible row-level tests and CI did. No separate behavior requirement remains in this notes-only PR.