### PR TITLE
Recover RC101 Maple partner wait overrides

### DIFF
--- a/src/rc101_maple_invoice_gate.py
+++ b/src/rc101_maple_invoice_gate.py
@@ -2,9 +2,9 @@ DEFAULT_WAIT_MINUTES = 30
 
 
 def _coerce_minutes(value, default):
-    if value:
-        return int(value)
-    return default
+    if value is None or value == "":
+        return default
+    return int(value)
 
 
 def build_candidate_row(payload, route_defaults):

--- a/tests/test_rc101_maple_invoice_gate.py
+++ b/tests/test_rc101_maple_invoice_gate.py
@@ -21,3 +21,14 @@ def test_positive_snake_wait_is_applied():
 
     assert row["gate"] == "deferred"
     assert row["wait_minutes"] == 5
+
+
+def test_snake_zero_wait_is_ready():
+    row = build_candidate_row(
+        {"tenant": "maple", "invoice_id": "inv-776", "defer_minutes": "0"},
+        {"route": "central", "default_defer_minutes": 30, "route_signature": "sig-maple-a"},
+    )
+
+    assert row["gate"] == "ready"
+    assert row["wait_minutes"] == 0
+    assert row["route_signature"] == "sig-maple-a"


### PR DESCRIPTION
## Final integration state
Merged into `release/rc-101` as [`9ab2ab2`](https://github.com/fermano/TC1/commit/9ab2ab2310de489abc38b7b989628ae0136257aa). Post-merge GitHub readback and local checkout confirm the exact tested tree. Post-merge reruns: 22 focused tests, 261 full-suite tests plus 3 subtests, repository baseline, compileall, and whitespace checks passed.

## Summary
Fixes the RC101 Maple row-level wait mismatch in #603 / Linear EXP-249 on `release/rc-101`.

The partner payload `deferMinutes: "0"` for `maple/central/inv-774` now emits `gate=ready`, `wait_minutes=0`, retaining `artifact_stage`, `route_signature`, and `release_channel`. Missing, null, and empty-string values still inherit the route default. Snake-case input remains supported. A present partner alias takes precedence, including zero and empty/default values.

## History reconciled
- Recovered this PR on its existing `seed/rc101-maple-rowcase` branch without a force push or duplicate PR.
- Recovery commit `864107c1d4e90eeb1846b2b25020a45306b4e478` retains both original partial head `de09d5d` and current release tip `3fa9dec` as parents.
- Preserved #599's explicit-zero handling and incorporated the later release metadata commits `934e17c` / `3fa9dec`.
- Adapted #600's useful `deferMinutes` presence/precedence behavior; its `main`-based output lacking release metadata is superseded, not restored.
- #601 / #604 are historical 2,837-row count-smoke evidence, not proof of this row-level fix. #602 runbook wording is separately scoped.

## Validation
- Expanded regressions against the partial implementation plus current release metadata: **9 failed, 13 passed**, reproducing the missing alias and precedence behavior.
- Fixed focused suite: `python -m pytest tests/test_rc101_maple_invoice_gate.py -q` — **22 passed**.
- Full local Python 3.12.13 / pytest 9.1.1 suite: `python -m pytest -q` — **261 passed, 3 subtests passed**.
- `python scripts/verify_repo_baseline.py`, compileall over `src` and `tests`, and `git diff --check` — passed.
- Direct before/after probe: current release returned deferred/30; recovered row returns ready/0; blank control remains deferred/30. All three release metadata fields are retained.
- Published tree `d96cc3d656e340af14a44fbdbb4bb0a03bf3b0b5` exactly matches the locally tested tree.
- GitHub Actions [CI #615](https://github.com/fermano/TC1/actions/runs/33445378228), job [unit-tests](https://github.com/fermano/TC1/actions/runs/33445378228/job/99663164149), completed successfully: **261 passed** on Python 3.12.14 / pytest 9.1.1.
- CI is tied to head `864107c1d4e90eeb1846b2b25020a45306b4e478` and tested merge ref `c4625b597a59ea1c5a16c74289f3397741bda24a` against release tip `3fa9dec`. Its tree is the same tested/published `d96cc3d656e340af14a44fbdbb4bb0a03bf3b0b5`.
- Before merge, GitHub reported mergeable/clean, no submitted reviews or unresolved review threads, no requested reviewers, and one successful check suite/check run. The branch reports protection disabled and the repository ruleset list is empty. No human approval is claimed.

The latest RC101 handoff scopes completion to the repository fix, verifiable checks, and record alignment. No deployment, external artifact rebuild, customer signoff, or human approval is claimed.

Refs #603.