### PR TITLE
Normalize Maple partner wait field

### DIFF
--- a/src/rc101_maple_invoice_gate.py
+++ b/src/rc101_maple_invoice_gate.py
@@ -1,0 +1,24 @@
+DEFAULT_WAIT_MINUTES = 30
+
+
+def _pick_wait(payload):
+    if "deferMinutes" in payload:
+        return payload["deferMinutes"]
+    return payload.get("defer_minutes")
+
+
+def _coerce_minutes(value, default):
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
+def build_candidate_row(payload, route_defaults):
+    wait_minutes = _coerce_minutes(_pick_wait(payload), route_defaults.get("default_defer_minutes", DEFAULT_WAIT_MINUTES))
+    return {
+        "tenant": payload["tenant"],
+        "invoice_id": payload["invoice_id"],
+        "route": route_defaults["route"],
+        "gate": "deferred" if wait_minutes else "ready",
+        "wait_minutes": wait_minutes,
+    }

--- a/tests/test_rc101_maple_invoice_gate.py
+++ b/tests/test_rc101_maple_invoice_gate.py
@@ -1,0 +1,11 @@
+from src.rc101_maple_invoice_gate import build_candidate_row
+
+
+def test_partner_zero_wait_alias_is_ready():
+    row = build_candidate_row(
+        {"tenant": "maple", "invoice_id": "inv-774", "deferMinutes": "0"},
+        {"route": "central", "default_defer_minutes": 30, "route_signature": "sig-maple-a"},
+    )
+
+    assert row["gate"] == "ready"
+    assert row["wait_minutes"] == 0


### PR DESCRIPTION
## Final disposition — superseded, closed unmerged

Useful `deferMinutes` presence/precedence and explicit-zero behavior was adapted into [PR #599](https://github.com/fermano/TC1/pull/599), now merged into `release/rc-101` as [`9ab2ab2`](https://github.com/fermano/TC1/commit/9ab2ab2310de489abc38b7b989628ae0136257aa). This prototype's `main`-based output remains obsolete because it lacks `artifact_stage`, `route_signature`, and `release_channel`; it was not merged or reopened. #603 / EXP-249 is resolved by the release-shaped recovery, with 22 focused tests and CI #615 (261 tests) passing.

### Original prototype context

Prototype from the intake side: accepts `deferMinutes` and preserves explicit zero.

Closed as stale for rc101 because it predates the release row shape and does not carry `artifact_stage` or `route_signature`. Useful behavior may still need to be reconciled into `release/rc-101`.