### PR TITLE
Record Maple rc101 candidate count readout

### DIFF
--- a/docs/rc101-maple-readout.md
+++ b/docs/rc101-maple-readout.md
@@ -1,0 +1,9 @@
+# RC101 Maple count readout
+
+Artifact `rc101-maple-b-17` was sampled after the release branch moved to `release/rc-101`.
+
+Count smoke: 2,837 candidate rows, matching the preview sheet.
+
+Line sample: `maple/central/inv-774` still shows `gate=deferred` and `wait_minutes=30` although the partner payload carries `deferMinutes: "0"`.
+
+Interpretation: count smoke is not the unblock by itself. The shape-specific row is the disputed signal.


### PR DESCRIPTION
## Final disposition — historical count context, closed unmerged

The existing b-17 count-smoke evidence is retained here and in #604. It is not a separate implementation requirement or proof of the Maple line-level classification. [PR #599](https://github.com/fermano/TC1/pull/599) resolved #603 on `release/rc-101` as [`9ab2ab2`](https://github.com/fermano/TC1/commit/9ab2ab2310de489abc38b7b989628ae0136257aa), with the exact release row and metadata covered by 22 focused tests and CI #615 (261 tests).

No new count mismatch is established, and no fresh 2,837-row artifact recount is claimed. This documentation-only PR is superseded by the verified recovery records, not merged as a fix. Linear EXP-250 remains Canceled/context.

### Original evidence

Records the count-smoke result for `rc101-maple-b-17`.

This is evidence only. The line sample for `maple/central/inv-774` still disagrees with the partner payload.