### PR TITLE
Make route-mode fallback explicit

### DIFF
--- a/src/coverage_review_tc1_covered_controls.py
+++ b/src/coverage_review_tc1_covered_controls.py
@@ -1,0 +1,6 @@
+def route_mode(value):
+    if value is None:
+        return "default"
+    if value == "manual":
+        return "manual"
+    return "automatic"

--- a/tests/test_coverage_review_tc1_covered_controls.py
+++ b/tests/test_coverage_review_tc1_covered_controls.py
@@ -1,0 +1,6 @@
+import pytest
+from src.coverage_review_tc1_covered_controls import route_mode
+
+@pytest.mark.parametrize(("value", "expected"), [(None, "default"), ("manual", "manual"), ("scheduled", "automatic")])
+def test_route_mode_covers_public_contract(value, expected):
+    assert route_mode(value) == expected


### PR DESCRIPTION
Adds a public route-mode helper with parameterized coverage for default, manual, and other values.