### PR TITLE
Honor legacy delay input in eligibility adapter

### DIFF
--- a/src/coverage_review_tc1_partner_boundary.py
+++ b/src/coverage_review_tc1_partner_boundary.py
@@ -1,0 +1,5 @@
+def resolve_partner_value(payload, default=30):
+    value = payload.get("send_after")
+    if value is None:
+        value = payload.get("sendAfter")
+    return default if value in (None, "") else value

--- a/tests/test_coverage_review_tc1_partner_boundary.py
+++ b/tests/test_coverage_review_tc1_partner_boundary.py
@@ -1,0 +1,7 @@
+from src.coverage_review_tc1_partner_boundary import resolve_partner_value
+
+def test_internal_value_is_preserved():
+    assert resolve_partner_value({"send_after": 0}) == 0
+
+def test_absent_value_uses_default():
+    assert resolve_partner_value({}) == 30


### PR DESCRIPTION
Adds a small intake helper for timing values. The included fixture covers the canonical internal field and defaulting; partner ingress replay is still only represented in the handoff notes.