### PR TITLE
Canonicalize status labels in support diagnostics

### DIFF
--- a/src/coverage_review_tc1_covered_contract.py
+++ b/src/coverage_review_tc1_covered_contract.py
@@ -1,0 +1,5 @@
+def canonical_label(value):
+    if value is None:
+        return "unknown"
+    value = value.strip().lower()
+    return value or "unknown"

--- a/tests/test_coverage_review_tc1_covered_contract.py
+++ b/tests/test_coverage_review_tc1_covered_contract.py
@@ -1,0 +1,6 @@
+import pytest
+from src.coverage_review_tc1_covered_contract import canonical_label
+
+@pytest.mark.parametrize(("value", "expected"), [(None, "unknown"), ("", "unknown"), ("  READY  ", "ready")])
+def test_canonical_label_contract(value, expected):
+    assert canonical_label(value) == expected


### PR DESCRIPTION
Adds a small public label normalizer with parameterized coverage for null, blank, and normalized values.