### PR TITLE
Cache retry targets by replay identity

### DIFF
--- a/src/review_seed_retry_targets.py
+++ b/src/review_seed_retry_targets.py
@@ -1,0 +1,4 @@
+"""Seed-only review fixture for replay identity."""
+
+def retry_target_key(tenant_id, route_id, event_id):
+    return f"{tenant_id}:{event_id}"


### PR DESCRIPTION
Small replay-cache helper used by the route path. This is intentionally scoped to the current key shape.