### PR TITLE
Preserve retry delay override during enqueue

### DIFF
--- a/src/review_seed_reschedule_delay.py
+++ b/src/review_seed_reschedule_delay.py
@@ -1,0 +1,4 @@
+"""Seed-only helper for the requested regression."""
+
+def reschedule_delay(value, default=30):
+    return default if value is None else int(value)


### PR DESCRIPTION
Narrow behavior helper whose review is expected to decide whether a replay-specific regression needs separate tracking.